### PR TITLE
Fixes runtime error on close()

### DIFF
--- a/fluent/fluent.go
+++ b/fluent/fluent.go
@@ -128,6 +128,10 @@ func (f *Fluent) close() (err error) {
 	if f.conn != nil {
 		f.mu.Lock()
 		defer f.mu.Unlock()
+	} else {
+		return
+	}
+	if f.conn != nil {
 		f.conn.Close()
 		f.conn = nil
 	}


### PR DESCRIPTION
If (*Fluent).close() is called from several goroutines at same time, runtime error like `runtime error: invalid memory address or nil pointer dereference goroutine 656846 [running]` occurs.
