### PR TITLE
Report unflushed buffer error from Close().

### DIFF
--- a/fluent/fluent.go
+++ b/fluent/fluent.go
@@ -121,9 +121,9 @@ func (f *Fluent) PostWithTime(tag string, tm time.Time, message interface{}) {
 // Close closes the connection.
 func (f *Fluent) Close() (err error) {
 	if len(f.pending) > 0 {
-		_ = f.send()
+		err = f.send()
 	}
-	err = f.close()
+	f.close()
 	return
 }
 


### PR DESCRIPTION
This patch makes it possible for the caller to detect whether any buffer contents were discarded by the Close().

The private close() function never returns an error, while the send() does, so it would make sense to return the result of the send() instead. The result of close() is constant.
