### PR TITLE
Change conn to io.WriteCloser from net.Conn

### DIFF
--- a/fluent/fluent.go
+++ b/fluent/fluent.go
@@ -3,6 +3,7 @@ package fluent
 import (
 	"errors"
 	"fmt"
+	"io"
 	"math"
 	"net"
 	"reflect"
@@ -33,7 +34,7 @@ type Config struct {
 
 type Fluent struct {
 	Config
-	conn         net.Conn
+	conn         io.WriteCloser
 	pending      []byte
 	reconnecting bool
 	mu           sync.Mutex


### PR DESCRIPTION
Fluent.conn can change to io.WriteCloser from net.Conn. io.WriteCloser is narrow and abstract interface. It may help testing.

For example Test_send_WritePendingToConn does not use network. It use bytes.Buffer instead of net.Conn, and checking received message is easy.