### PR TITLE
Remove lock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ install:
   - go get github.com/bmizerany/assert
   - go get github.com/philhofer/fwd
   - go get github.com/tinylib/msgp
+  - go get golang.org/x/net/context
 sudo: false
 matrix:
   allow_failures:

--- a/fluent/fluent_test.go
+++ b/fluent/fluent_test.go
@@ -111,17 +111,17 @@ func Test_New_itShouldUseConfigValuesFromArguments(t *testing.T) {
 	assert.Equal(t, f.Config.FluentHost, "foobarhost")
 }
 
-func Test_send_WritePendingToConn(t *testing.T) {
-	f := &Fluent{Config: Config{}, reconnecting: false}
+func Test_send_WriteBufferToConn(t *testing.T) {
+	f := &Fluent{Config: Config{}}
 
 	buf := &Conn{}
 	f.conn = buf
 
 	msg := "This is test writing."
 	bmsg := []byte(msg)
-	f.pending = append(f.pending, bmsg...)
+	f.buf = append(f.buf, bmsg...)
 
-	err := f.send()
+	err := f.send(f.buf)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
f.conn and f.reconnecting is like is not enough read / write lock, because rarely f.conn had be panic in the conflict, I've made the following changes.
- To stop the use of the lock, it was rewritten to channel base
- Without panic, Add PostRawDataWithResult return an error instead
- Add SyncPost option (to synchronize processes the connect and write)

I'm sorry in "google translation"
