### PR TITLE
Fix bug not to reconnect twice or more after logger once recovered disconnection

### DIFF
--- a/_examples/main.go
+++ b/_examples/main.go
@@ -2,15 +2,13 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"time"
 
 	"../fluent"
-
-	"github.com/Sirupsen/logrus"
 )
 
 func main() {
-	logrus.SetLevel(logrus.DebugLevel)
 	logger, err := fluent.New(fluent.Config{FluentPort: 24224, FluentHost: "127.0.0.1"})
 	if err != nil {
 		fmt.Println(err)
@@ -24,9 +22,9 @@ func main() {
 	for i < 100 {
 		e := logger.Post(tag, data)
 		if e != nil {
-			logrus.Debugf("Error while posting log: %s", e)
+			log.Println("Error while posting log: ", e)
 		} else {
-			logrus.Debug("Success to post log")
+			log.Println("Success to post log")
 		}
 		i = i + 1
 		time.Sleep(1000 * time.Millisecond)

--- a/_examples/main.go
+++ b/_examples/main.go
@@ -2,11 +2,15 @@ package main
 
 import (
 	"fmt"
-	"github.com/fluent/fluent-logger-golang/fluent"
-	// "../fluent"
+	"time"
+
+	"../fluent"
+
+	"github.com/Sirupsen/logrus"
 )
 
 func main() {
+	logrus.SetLevel(logrus.DebugLevel)
 	logger, err := fluent.New(fluent.Config{FluentPort: 24224, FluentHost: "127.0.0.1"})
 	if err != nil {
 		fmt.Println(err)
@@ -18,7 +22,13 @@ func main() {
 		"hoge": "hoge"}
 	i := 0
 	for i < 100 {
-		logger.Post(tag, data)
+		e := logger.Post(tag, data)
+		if e != nil {
+			logrus.Debugf("Error while posting log: %s", e)
+		} else {
+			logrus.Debug("Success to post log")
+		}
 		i = i + 1
+		time.Sleep(1000 * time.Millisecond)
 	}
 }

--- a/_examples/main.go
+++ b/_examples/main.go
@@ -18,15 +18,13 @@ func main() {
 	var data = map[string]string{
 		"foo":  "bar",
 		"hoge": "hoge"}
-	i := 0
-	for i < 100 {
+	for i := 0; i < 100; i++ {
 		e := logger.Post(tag, data)
 		if e != nil {
 			log.Println("Error while posting log: ", e)
 		} else {
 			log.Println("Success to post log")
 		}
-		i = i + 1
 		time.Sleep(1000 * time.Millisecond)
 	}
 }

--- a/fluent/fluent.go
+++ b/fluent/fluent.go
@@ -254,7 +254,7 @@ func (f *Fluent) connect() (err error) {
 		err = net.UnknownNetworkError(f.Config.FluentNetwork)
 	}
 
-	if err != nil {
+	if err == nil {
 		f.reconnecting = false
 	}
 	return


### PR DESCRIPTION
This change will fix a bug not to reconnect to destination twice or more (#38 and originally docker/docker#27374).
This bug was occured by clearing `reconnecting` flag wrongly when re-connection failed (err != nil).

This occurs:
* create many goroutines to call reconnect method
* not to reconnect again after logger once experienced disconnection and reconnection
