### PR TITLE
Added fluent-logger-ruby compatible BufferOverflowHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ func main() {
 f := fluent.New(fluent.Config{FluentPort: 80, FluentHost: "example.com"})
 ```
 
+## Buffer overflow
+
+You can inject your own custom func to handle buffer overflow in the event of connection failure.
+This will mitigate the loss of data instead of simply rejecting data and ending up throwing data away.
+
+Your func must accept a single argument, which will be the internal buffer of messages from the logger.
+This func is also called when logger.Close() failed to send the remaining internal buffer of messages.
+A typical use-case for this would be writing to disk or possibly writing to Redis.
+
 ## Tests
 ```
 go test

--- a/fluent/fluent_test.go
+++ b/fluent/fluent_test.go
@@ -3,6 +3,7 @@ package fluent
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net"
 	"reflect"
@@ -319,6 +320,67 @@ func Test_BufferOverFlow(t *testing.T) {
 	}
 }
 
+func Test_BufferOverFlowHandler(t *testing.T) {
+	f, err := New(Config{
+		FluentPort:    6666,
+		AsyncConnect:  false,
+		MarshalAsJSON: true,     // easy to check equality
+		BufferLimit:   1 * 1024, // to buffer over flow
+	})
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	var testData = []struct {
+		in         map[string]string
+		handlerErr error
+		out        string
+		outErr     error
+	}{
+		{
+			map[string]string{"k": strings.Repeat("v", 1024)},
+			nil,
+			fmt.Sprintf("[\"tag_name\",1482493046,{\"k\":\"%s\"},null]",
+				strings.Repeat("v", 1024)),
+			nil,
+		},
+		{
+			map[string]string{"k": strings.Repeat("v", 1024)},
+			fmt.Errorf("handler problem"),
+			fmt.Sprintf("[\"tag_name\",1482493046,{\"k\":\"%s\"},null]",
+				strings.Repeat("v", 1024)),
+			fmt.Errorf("fluent#appendBuffer: Buffer full, limit 1024 and next error is fluent#callBufferOverflowHandler: Can't call buffer overflow handler: handler problem"),
+		},
+	}
+	for _, tt := range testData {
+		var handlerBuf []byte
+		f.Config.BufferOverflowHandler = func(pending []byte) error {
+			handlerBuf = make([]byte, len(pending))
+			copy(handlerBuf, pending)
+			return tt.handlerErr
+		}
+
+		buf := &Conn{}
+		f.conn = buf
+
+		err = f.PostWithTime("tag_name", time.Unix(1482493046, 0), tt.in)
+		if err != tt.outErr && err.Error() != tt.outErr.Error() {
+			t.Errorf("got %s, except %s, in %s", err, tt.outErr, tt.in)
+		}
+
+		rcv := buf.String()
+		if rcv != "" {
+			t.Errorf("got %s, except empty", rcv)
+		}
+
+		overflow := string(handlerBuf)
+		if overflow != tt.out {
+			t.Errorf("got %s, except %s", overflow, tt.out)
+		}
+	}
+}
+
 func Test_Close(t *testing.T) {
 	f, err := New(Config{
 		FluentPort:    6666,
@@ -357,6 +419,62 @@ func Test_Close(t *testing.T) {
 		rcv := buf.String()
 		if rcv != tt.out {
 			t.Errorf("got %s, except %s", rcv, tt.out)
+		}
+	}
+}
+
+func Test_CloseWithBufferOverflowHandler(t *testing.T) {
+	f, err := New(Config{
+		FluentPort:    6666,
+		AsyncConnect:  false,
+		MarshalAsJSON: true, // easy to check equality
+	})
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	var testData = []struct {
+		in         string
+		handlerErr error
+		out        string
+		outErr     error
+	}{
+		{
+			"This is test writing",
+			nil,
+			"This is test writing",
+			nil,
+		},
+		{
+			"This is another test writing",
+			fmt.Errorf("handler problem"),
+			"This is another test writing",
+			fmt.Errorf("fluent#send: can't send logs, client is reconnecting and next error is fluent#callBufferOverflowHandler: Can't call buffer overflow handler: handler problem"),
+		},
+	}
+	for _, tt := range testData {
+		var handlerBuf []byte
+		f.Config.BufferOverflowHandler = func(pending []byte) error {
+			handlerBuf = make([]byte, len(pending))
+			copy(handlerBuf, pending)
+			return tt.handlerErr
+		}
+
+		// cause error of send() and stop retrying send()
+		f.conn = nil
+		f.reconnecting = true
+
+		f.pending = []byte(tt.in)
+
+		err := f.Close()
+		if err != tt.outErr && err.Error() != tt.outErr.Error() {
+			t.Errorf("got %s, except %s, in %s", err, tt.outErr, tt.in)
+		}
+
+		overflow := string(handlerBuf)
+		if overflow != tt.out {
+			t.Errorf("got %s, except %s", overflow, tt.out)
 		}
 	}
 }


### PR DESCRIPTION
fluent-logger-golang does nothing when the fluentd buffer was reached on buffer_limit. 

This PR can mitigate the loss of data instead of simply rejecting data and ending up throwing data away. 

If no BufferOverflowHandler is provided in the Config, there is no change in behaviour.

- ref.
  - [Allow injection of buffer overflow handler #33 · fluent/fluent-logger-ruby](https://github.com/fluent/fluent-logger-ruby/pull/33)
  - [Added fluent-logger-ruby compatible buffer_overflow_handle fluent/fluent-logger-perl](https://github.com/fluent/fluent-logger-perl/pull/17)