### PR TITLE
Remove wrong comments for 'f.Post(tag_name, "data")'

### DIFF
--- a/fluent/fluent.go
+++ b/fluent/fluent.go
@@ -90,9 +90,6 @@ func New(config Config) (f *Fluent, err error) {
 //
 // Examples:
 //
-//  // send string
-//  f.Post("tag_name", "data")
-//
 //  // send map[string]
 //  mapStringData := map[string]string{
 //  	"foo":  "bar",


### PR DESCRIPTION
Causing error like 

```
fluent#PostWithTime: message must be a map
```