### PR TITLE
Add a new option to set a timeout to logger.Post

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ func main() {
 f := fluent.New(fluent.Config{FluentPort: 80, FluentHost: "example.com"})
 ```
 
+### WriteTimeout
+
+Sets the timeout for Write call of logger.Post.
+Since the default is zero value, Write will not time out.
+
 ## Tests
 ```
 go test

--- a/fluent/fluent_test.go
+++ b/fluent/fluent_test.go
@@ -1,7 +1,6 @@
 package fluent
 
 import (
-	"bytes"
 	"encoding/json"
 	"io/ioutil"
 	"net"
@@ -19,7 +18,23 @@ const (
 
 // Conn is io.WriteCloser
 type Conn struct {
-	bytes.Buffer
+	net.Conn
+	buf []byte
+}
+
+func (c *Conn) Read(b []byte) (int, error) {
+	copy(b, c.buf)
+	return len(c.buf), nil
+}
+
+func (c *Conn) Write(b []byte) (int, error) {
+	c.buf = make([]byte, len(b))
+	copy(c.buf, b)
+	return len(b), nil
+}
+
+func (c *Conn) SetWriteDeadline(t time.Time) error {
+	return nil
 }
 
 func (c *Conn) Close() error {
@@ -66,6 +81,7 @@ func Test_New_itShouldUseDefaultConfigValuesIfNoOtherProvided(t *testing.T) {
 	assert.Equal(t, f.Config.FluentPort, defaultPort)
 	assert.Equal(t, f.Config.FluentHost, defaultHost)
 	assert.Equal(t, f.Config.Timeout, defaultTimeout)
+	assert.Equal(t, f.Config.WriteTimeout, defaultWriteTimeout)
 	assert.Equal(t, f.Config.BufferLimit, defaultBufferLimit)
 	assert.Equal(t, f.Config.FluentNetwork, defaultNetwork)
 	assert.Equal(t, f.Config.FluentSocketPath, defaultSocketPath)
@@ -124,8 +140,8 @@ func Test_New_itShouldUseConfigValuesFromMashalAsJSONArgument(t *testing.T) {
 func Test_send_WritePendingToConn(t *testing.T) {
 	f := &Fluent{Config: Config{}, reconnecting: false}
 
-	buf := &Conn{}
-	f.conn = buf
+	conn := &Conn{}
+	f.conn = conn
 
 	msg := "This is test writing."
 	bmsg := []byte(msg)
@@ -136,17 +152,18 @@ func Test_send_WritePendingToConn(t *testing.T) {
 		t.Error(err)
 	}
 
-	rcv := buf.String()
-	if rcv != msg {
-		t.Errorf("got %s, except %s", rcv, msg)
+	rcv := make([]byte, len(conn.buf))
+	_, err = conn.Read(rcv)
+	if string(rcv) != msg {
+		t.Errorf("got %s, except %s", string(rcv), msg)
 	}
 }
 
 func Test_MarshalAsMsgpack(t *testing.T) {
 	f := &Fluent{Config: Config{}, reconnecting: false}
 
-	buf := &Conn{}
-	f.conn = buf
+	conn := &Conn{}
+	f.conn = conn
 
 	tag := "tag"
 	var data = map[string]string{
@@ -171,8 +188,8 @@ func Test_MarshalAsMsgpack(t *testing.T) {
 func Test_MarshalAsJSON(t *testing.T) {
 	f := &Fluent{Config: Config{MarshalAsJSON: true}, reconnecting: false}
 
-	buf := &Conn{}
-	f.conn = buf
+	conn := &Conn{}
+	f.conn = conn
 
 	var data = map[string]string{
 		"foo":  "bar",
@@ -203,6 +220,7 @@ func TestJsonConfig(t *testing.T) {
 		FluentNetwork:    "tcp",
 		FluentSocketPath: "/var/tmp/fluent.sock",
 		Timeout:          3000,
+		WriteTimeout:     6000,
 		BufferLimit:      200,
 		RetryWait:        5,
 		MaxRetry:         3,
@@ -273,17 +291,19 @@ func Test_PostWithTime(t *testing.T) {
 		},
 	}
 	for _, tt := range testData {
-		buf := &Conn{}
-		f.conn = buf
+		conn := &Conn{}
+		f.conn = conn
 
 		err = f.PostWithTime("tag_name", time.Unix(1482493046, 0), tt.in)
 		if err != nil {
 			t.Errorf("in=%s, err=%s", tt.in, err)
 		}
 
-		rcv := buf.String()
-		if rcv != tt.out {
-			t.Errorf("got %s, except %s", rcv, tt.out)
+		rcv := make([]byte, len(conn.buf))
+		_, err = conn.Read(rcv)
+		if string(rcv) != tt.out {
+			t.Errorf("got %s, except %s", string(rcv), tt.out)
+		}
 		}
 	}
 }

--- a/fluent/fluent_test.go
+++ b/fluent/fluent_test.go
@@ -16,7 +16,7 @@ const (
 	RECV_BUF_LEN = 1024
 )
 
-// Conn is io.WriteCloser
+// Conn is net.Conn with the parameters to be verified in the test
 type Conn struct {
 	net.Conn
 	buf           []byte

--- a/fluent/fluent_test.go
+++ b/fluent/fluent_test.go
@@ -268,7 +268,7 @@ func TestAsyncConnect(t *testing.T) {
 	}
 }
 
-func Test_PostWithTime(t *testing.T) {
+func Test_PostWithTimeNotTimeOut(t *testing.T) {
 	f, err := New(Config{
 		FluentPort:    6666,
 		AsyncConnect:  false,

--- a/fluent/fluent_test.go
+++ b/fluent/fluent_test.go
@@ -19,7 +19,8 @@ const (
 // Conn is io.WriteCloser
 type Conn struct {
 	net.Conn
-	buf []byte
+	buf           []byte
+	writeDeadline time.Time
 }
 
 func (c *Conn) Read(b []byte) (int, error) {
@@ -34,6 +35,7 @@ func (c *Conn) Write(b []byte) (int, error) {
 }
 
 func (c *Conn) SetWriteDeadline(t time.Time) error {
+	c.writeDeadline = t
 	return nil
 }
 
@@ -304,6 +306,9 @@ func Test_PostWithTime(t *testing.T) {
 		if string(rcv) != tt.out {
 			t.Errorf("got %s, except %s", string(rcv), tt.out)
 		}
+
+		if !conn.writeDeadline.IsZero() {
+			t.Errorf("got %s, except 0", conn.writeDeadline)
 		}
 	}
 }

--- a/fluent/testdata/config.json
+++ b/fluent/testdata/config.json
@@ -4,6 +4,7 @@
   "fluent_network":"tcp",
   "fluent_socket_path":"/var/tmp/fluent.sock",
   "timeout":3000,
+  "write_timeout":6000,
   "buffer_limit":200,
   "retry_wait":5,
   "max_retry":3,


### PR DESCRIPTION
See [[v1.2.1] logger.Post blocks forever when the fluentd server has a certain trouble #44](https://github.com/fluent/fluent-logger-golang/issues/44)

To test,

```
# main.go from the linked issue
## I confirmed that logger.post did not time out as before.
$ go run main.go
2017/03/19 19:25:21 Success to post log:  0
2017/03/19 19:25:21 Success to post log:  10000
^Csignal: interrupt

# main.go patched the below diff
## I confirmed that logger.post timed out after 3 seconds.
$ go run main.go
2017/03/19 19:30:49 Success to post log:  0
2017/03/19 19:30:49 Success to post log:  10000
2017/03/19 19:30:52 Error while posting log:  write tcp 127.0.0.1:62548->127.0.0.1:24224: i/o timeout
2017/03/19 19:30:52 Error while posting log:  fluent#send: can't send logs, client is reconnecting
2017/03/19 19:30:52 Error while posting log:  fluent#send: can't send logs, client is reconnecting
2017/03/19 19:30:53 Success to post log:  20000
2017/03/19 19:30:56 Error while posting log:  write tcp 127.0.0.1:62549->127.0.0.1:24224: i/o timeout
2017/03/19 19:30:56 Error while posting log:  fluent#send: can't send logs, client is reconnecting
2017/03/19 19:30:56 Error while posting log:  fluent#send: can't send logs, client is reconnecting
2017/03/19 19:30:56 Error while posting log:  fluent#send: can't send logs, client is reconnecting
2017/03/19 19:30:56 Success to post log:  30000
^Csignal: interrupt
```

```diff
$ git diff
diff --git a/fluent-logger/main.go b/fluent-logger/main.go
index 37f72d6..eb5614a 100644
--- a/fluent-logger/main.go
+++ b/fluent-logger/main.go
@@ -3,14 +3,16 @@ package main
 import (
        "fmt"
        "log"
+       "time"

        "github.com/fluent/fluent-logger-golang/fluent"
 )

 func main() {
        logger, err := fluent.New(fluent.Config{
               FluentPort: 24224,
               FluentHost: "127.0.0.1",
+              WriteTimeout: 3 * time.Second,
        })
        if err != nil {
                fmt.Println(err)
```