### PR TITLE
Add RetryForever option to wait Fluentd connection forever

### DIFF
--- a/fluent/fluent.go
+++ b/fluent/fluent.go
@@ -38,6 +38,7 @@ type Config struct {
 	TagPrefix        string        `json:"tag_prefix"`
 	AsyncConnect     bool          `json:"async_connect"`
 	MarshalAsJSON    bool          `json:"marshal_as_json"`
+	RetryForever     bool          `json:"retry_forever"`
 }
 
 type Fluent struct {
@@ -275,7 +276,7 @@ func (f *Fluent) reconnect() {
 			f.send()
 			return
 		}
-		if i == f.Config.MaxRetry {
+		if !f.Config.RetryForever && i == f.Config.MaxRetry {
 			// TODO: What we can do when connection failed MaxRetry times?
 			panic("fluent#reconnect: failed to reconnect!")
 		}

--- a/fluent/fluent_test.go
+++ b/fluent/fluent_test.go
@@ -87,6 +87,7 @@ func Test_New_itShouldUseDefaultConfigValuesIfNoOtherProvided(t *testing.T) {
 	assert.Equal(t, f.Config.BufferLimit, defaultBufferLimit)
 	assert.Equal(t, f.Config.FluentNetwork, defaultNetwork)
 	assert.Equal(t, f.Config.FluentSocketPath, defaultSocketPath)
+	assert.Equal(t, f.Config.RetryForever, false)
 }
 
 func Test_New_itShouldUseUnixDomainSocketIfUnixSocketSpecified(t *testing.T) {
@@ -137,6 +138,11 @@ func Test_New_itShouldUseConfigValuesFromArguments(t *testing.T) {
 func Test_New_itShouldUseConfigValuesFromMashalAsJSONArgument(t *testing.T) {
 	f, _ := New(Config{MarshalAsJSON: true})
 	assert.Equal(t, f.Config.MarshalAsJSON, true)
+}
+
+func Test_New_itShouldUseConfigValuesFromRetryForeverArgument(t *testing.T) {
+	f, _ := New(Config{RetryForever: true})
+	assert.Equal(t, f.Config.RetryForever, true)
 }
 
 func Test_send_WritePendingToConn(t *testing.T) {


### PR DESCRIPTION
I've tried to add `RetryForever` explicit option to wait forever for Fluentd connection.