### PR TITLE
Async send

### DIFF
--- a/fluent/fluent.go
+++ b/fluent/fluent.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"net"
+	"os"
 	"reflect"
 	"strconv"
 	"sync"
@@ -19,7 +20,7 @@ const (
 	defaultPort                   = 24224
 	defaultTimeout                = 3 * time.Second
 	defaultWriteTimeout           = time.Duration(0) // Write() will not time out
-	defaultBufferLimit            = 8 * 1024 * 1024
+	defaultBufferSize             = 8 * 1024
 	defaultRetryWait              = 500
 	defaultMaxRetry               = 13
 	defaultReconnectWaitIncreRate = 1.5
@@ -35,11 +36,11 @@ type Config struct {
 	FluentSocketPath string        `json:"fluent_socket_path"`
 	Timeout          time.Duration `json:"timeout"`
 	WriteTimeout     time.Duration `json:"write_timeout"`
-	BufferLimit      int           `json:"buffer_limit"`
+	BufferSize       int           `json:"buffer_size"`
 	RetryWait        int           `json:"retry_wait"`
 	MaxRetry         int           `json:"max_retry"`
 	TagPrefix        string        `json:"tag_prefix"`
-	AsyncConnect     bool          `json:"async_connect"`
+	Async            bool          `json:"async"`
 	MarshalAsJSON    bool          `json:"marshal_as_json"`
 
 	// Sub-second precision timestamps are only possible for those using fluentd
@@ -50,12 +51,11 @@ type Config struct {
 type Fluent struct {
 	Config
 
-	mubuff  sync.Mutex
-	pending []byte
+	pending chan []byte
+	wg      sync.WaitGroup
 
-	muconn       sync.Mutex
-	conn         net.Conn
-	reconnecting bool
+	muconn sync.Mutex
+	conn   net.Conn
 }
 
 // New creates a new Logger.
@@ -78,8 +78,8 @@ func New(config Config) (f *Fluent, err error) {
 	if config.WriteTimeout == 0 {
 		config.WriteTimeout = defaultWriteTimeout
 	}
-	if config.BufferLimit == 0 {
-		config.BufferLimit = defaultBufferLimit
+	if config.BufferSize == 0 {
+		config.BufferSize = defaultBufferSize
 	}
 	if config.RetryWait == 0 {
 		config.RetryWait = defaultRetryWait
@@ -87,11 +87,14 @@ func New(config Config) (f *Fluent, err error) {
 	if config.MaxRetry == 0 {
 		config.MaxRetry = defaultMaxRetry
 	}
-	if config.AsyncConnect {
-		f = &Fluent{Config: config, reconnecting: true}
-		go f.reconnect()
+	if config.Async {
+		f = &Fluent{
+			Config:  config,
+			pending: make(chan []byte, config.BufferSize),
+		}
+		go f.run()
 	} else {
-		f = &Fluent{Config: config, reconnecting: false}
+		f = &Fluent{Config: config}
 		err = f.connect()
 	}
 	return
@@ -184,14 +187,11 @@ func (f *Fluent) PostRawData(data []byte) {
 }
 
 func (f *Fluent) postRawData(data []byte) error {
-	if err := f.appendBuffer(data); err != nil {
-		return err
+	if f.Config.Async {
+		return f.appendBuffer(data)
 	}
-	if err := f.send(); err != nil {
-		f.close()
-		return err
-	}
-	return nil
+	// Synchronous write
+	return f.write(data)
 }
 
 // For sending forward protocol adopted JSON
@@ -224,10 +224,10 @@ func (f *Fluent) EncodeData(tag string, tm time.Time, message interface{}) (data
 	return
 }
 
-// Close closes the connection.
+// Close closes the connection, waiting for pending logs to be sent
 func (f *Fluent) Close() (err error) {
-	if len(f.pending) > 0 {
-		err = f.send()
+	if f.Config.Async {
+		f.wg.Wait()
 	}
 	f.close()
 	return
@@ -235,12 +235,13 @@ func (f *Fluent) Close() (err error) {
 
 // appendBuffer appends data to buffer with lock.
 func (f *Fluent) appendBuffer(data []byte) error {
-	f.mubuff.Lock()
-	defer f.mubuff.Unlock()
-	if len(f.pending)+len(data) > f.Config.BufferLimit {
-		return errors.New(fmt.Sprintf("fluent#appendBuffer: Buffer full, limit %v", f.Config.BufferLimit))
+	f.wg.Add(1)
+	select {
+	case f.pending <- data:
+	default:
+		f.wg.Done()
+		return fmt.Errorf("fluent#appendBuffer: Buffer full, limit %v", f.Config.BufferSize)
 	}
-	f.pending = append(f.pending, data...)
 	return nil
 }
 
@@ -256,8 +257,6 @@ func (f *Fluent) close() {
 
 // connect establishes a new connection using the specified transport.
 func (f *Fluent) connect() (err error) {
-	f.muconn.Lock()
-	defer f.muconn.Unlock()
 
 	switch f.Config.FluentNetwork {
 	case "tcp":
@@ -269,7 +268,6 @@ func (f *Fluent) connect() (err error) {
 	}
 
 	if err == nil {
-		f.reconnecting = false
 		t := f.Config.WriteTimeout
 		if time.Duration(0) < t {
 			f.conn.SetWriteDeadline(time.Now().Add(t))
@@ -280,50 +278,48 @@ func (f *Fluent) connect() (err error) {
 	return
 }
 
+func (f *Fluent) run() {
+	for {
+		select {
+		case entry := <-f.pending:
+			err := f.write(entry)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "[%s] Unable to send logs to fluentd, reconnecting...\n", time.Now().Format(time.RFC3339))
+			}
+			f.wg.Done()
+		}
+	}
+}
+
 func e(x, y float64) int {
 	return int(math.Pow(x, y))
 }
 
-func (f *Fluent) reconnect() {
-	for i := 0; ; i++ {
-		err := f.connect()
-		if err == nil {
-			f.send()
-			return
+func (f *Fluent) write(data []byte) error {
+
+	for i := 0; i < f.Config.MaxRetry; i++ {
+
+		// Connect if needed
+		f.muconn.Lock()
+		if f.conn == nil {
+			err := f.connect()
+			if err != nil {
+				f.muconn.Unlock()
+				waitTime := f.Config.RetryWait * e(defaultReconnectWaitIncreRate, float64(i-1))
+				time.Sleep(time.Duration(waitTime) * time.Millisecond)
+				continue
+			}
 		}
-		if i == f.Config.MaxRetry {
-			// TODO: What we can do when connection failed MaxRetry times?
-			panic("fluent#reconnect: failed to reconnect!")
-		}
-		waitTime := f.Config.RetryWait * e(defaultReconnectWaitIncreRate, float64(i-1))
-		time.Sleep(time.Duration(waitTime) * time.Millisecond)
-	}
-}
+		f.muconn.Unlock()
 
-func (f *Fluent) send() error {
-	f.muconn.Lock()
-	defer f.muconn.Unlock()
-
-	if f.conn == nil {
-		if f.reconnecting == false {
-			f.reconnecting = true
-			go f.reconnect()
-		}
-		return errors.New("fluent#send: can't send logs, client is reconnecting")
-	}
-
-	f.mubuff.Lock()
-	defer f.mubuff.Unlock()
-
-	var err error
-	if len(f.pending) > 0 {
-		_, err = f.conn.Write(f.pending)
+		// We're connected, write data
+		_, err := f.conn.Write(data)
 		if err != nil {
-			f.conn.Close()
-			f.conn = nil
+			f.close()
 		} else {
-			f.pending = f.pending[:0]
+			return err
 		}
 	}
-	return err
+
+	return errors.New("fluent#write: failed to reconnect")
 }

--- a/fluent/fluent.go
+++ b/fluent/fluent.go
@@ -270,6 +270,12 @@ func (f *Fluent) connect() (err error) {
 
 	if err == nil {
 		f.reconnecting = false
+		t := f.Config.WriteTimeout
+		if time.Duration(0) < t {
+			f.conn.SetWriteDeadline(time.Now().Add(t))
+		} else {
+			f.conn.SetWriteDeadline(time.Time{})
+		}
 	}
 	return
 }
@@ -311,12 +317,6 @@ func (f *Fluent) send() error {
 
 	var err error
 	if len(f.pending) > 0 {
-		t := f.Config.WriteTimeout
-		if time.Duration(0) < t {
-			f.conn.SetWriteDeadline(time.Now().Add(t))
-		} else {
-			f.conn.SetWriteDeadline(time.Time{})
-		}
 		_, err = f.conn.Write(f.pending)
 		if err != nil {
 			f.conn.Close()

--- a/fluent/fluent_test.go
+++ b/fluent/fluent_test.go
@@ -84,7 +84,7 @@ func Test_New_itShouldUseDefaultConfigValuesIfNoOtherProvided(t *testing.T) {
 	assert.Equal(t, f.Config.FluentHost, defaultHost)
 	assert.Equal(t, f.Config.Timeout, defaultTimeout)
 	assert.Equal(t, f.Config.WriteTimeout, defaultWriteTimeout)
-	assert.Equal(t, f.Config.BufferLimit, defaultBufferLimit)
+	assert.Equal(t, f.Config.BufferSize, defaultBufferSize)
 	assert.Equal(t, f.Config.FluentNetwork, defaultNetwork)
 	assert.Equal(t, f.Config.FluentSocketPath, defaultSocketPath)
 }
@@ -140,16 +140,16 @@ func Test_New_itShouldUseConfigValuesFromMashalAsJSONArgument(t *testing.T) {
 }
 
 func Test_send_WritePendingToConn(t *testing.T) {
-	f := &Fluent{Config: Config{}, reconnecting: false}
+	f, _ := New(Config{Async: true})
 
 	conn := &Conn{}
 	f.conn = conn
 
 	msg := "This is test writing."
 	bmsg := []byte(msg)
-	f.pending = append(f.pending, bmsg...)
+	f.pending <- bmsg
 
-	err := f.send()
+	err := f.write(bmsg)
 	if err != nil {
 		t.Error(err)
 	}
@@ -159,10 +159,12 @@ func Test_send_WritePendingToConn(t *testing.T) {
 	if string(rcv) != msg {
 		t.Errorf("got %s, except %s", string(rcv), msg)
 	}
+
+	f.Close()
 }
 
 func Test_MarshalAsMsgpack(t *testing.T) {
-	f := &Fluent{Config: Config{}, reconnecting: false}
+	f := &Fluent{Config: Config{}}
 
 	conn := &Conn{}
 	f.conn = conn
@@ -193,7 +195,6 @@ func Test_SubSecondPrecision(t *testing.T) {
 		Config: Config{
 			SubSecondPrecision: true,
 		},
-		reconnecting: false,
 	}
 	fluent.conn = &Conn{}
 
@@ -215,7 +216,7 @@ func Test_SubSecondPrecision(t *testing.T) {
 }
 
 func Test_MarshalAsJSON(t *testing.T) {
-	f := &Fluent{Config: Config{MarshalAsJSON: true}, reconnecting: false}
+	f := &Fluent{Config: Config{MarshalAsJSON: true}}
 
 	conn := &Conn{}
 	f.conn = conn
@@ -250,11 +251,11 @@ func TestJsonConfig(t *testing.T) {
 		FluentSocketPath: "/var/tmp/fluent.sock",
 		Timeout:          3000,
 		WriteTimeout:     6000,
-		BufferLimit:      200,
+		BufferSize:       10,
 		RetryWait:        5,
 		MaxRetry:         3,
 		TagPrefix:        "fluent",
-		AsyncConnect:     false,
+		Async:            false,
 		MarshalAsJSON:    true,
 	}
 
@@ -276,8 +277,8 @@ func TestAsyncConnect(t *testing.T) {
 	ch := make(chan result, 1)
 	go func() {
 		config := Config{
-			FluentPort:   8888,
-			AsyncConnect: true,
+			FluentPort: 8888,
+			Async:      true,
 		}
 		f, err := New(config)
 		ch <- result{f: f, err: err}
@@ -291,14 +292,14 @@ func TestAsyncConnect(t *testing.T) {
 		}
 		res.f.Close()
 	case <-time.After(time.Millisecond * 500):
-		t.Error("AsyncConnect must not block")
+		t.Error("Async must not block")
 	}
 }
 
 func Test_PostWithTimeNotTimeOut(t *testing.T) {
 	f, err := New(Config{
 		FluentPort:    6666,
-		AsyncConnect:  false,
+		Async:         false,
 		MarshalAsJSON: true, // easy to check equality
 	})
 	if err != nil {

--- a/fluent/testdata/config.json
+++ b/fluent/testdata/config.json
@@ -5,10 +5,10 @@
   "fluent_socket_path":"/var/tmp/fluent.sock",
   "timeout":3000,
   "write_timeout":6000,
-  "buffer_limit":200,
+  "buffer_size":10,
   "retry_wait":5,
   "max_retry":3,
   "tag_prefix":"fluent",
-  "async_connect": false,
+  "async": false,
   "marshal_as_json": true
 }


### PR DESCRIPTION
We are using fluent logging in performance critical services and want to ensure fluent request can't impact service response time.

Commit 127a588 introduces a new "Async" configuration directive that reuse existing async connect feature but also offers asynchronous send operation.
Please note the branch includes several breaking changes:
- configuration AsyncConnect and BufferLimit are renamed.
- synchronous mode is now always synchronous (no more async reconnect).
- errors during reconnect no longer cause panic.

I totally understand these changes can cause issues for existing users and I'd be happy to discuss other options.

Should fix #33.