### PR TITLE
Async send

### DIFF
--- a/fluent/fluent.go
+++ b/fluent/fluent.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"net"
+	"os"
 	"reflect"
 	"strconv"
 	"sync"
@@ -21,7 +22,7 @@ const (
 	defaultPort                   = 24224
 	defaultTimeout                = 3 * time.Second
 	defaultWriteTimeout           = time.Duration(0) // Write() will not time out
-	defaultBufferLimit            = 8 * 1024 * 1024
+	defaultBufferLimit            = 8 * 1024
 	defaultRetryWait              = 500
 	defaultMaxRetryWait           = 60000
 	defaultMaxRetry               = 13
@@ -43,8 +44,10 @@ type Config struct {
 	MaxRetry         int           `json:"max_retry"`
 	MaxRetryWait     int           `json:"max_retry_wait"`
 	TagPrefix        string        `json:"tag_prefix"`
-	AsyncConnect     bool          `json:"async_connect"`
-	MarshalAsJSON    bool          `json:"marshal_as_json"`
+	Async            bool          `json:"async"`
+	// Deprecated: Use Async instead
+	AsyncConnect  bool `json:"async_connect"`
+	MarshalAsJSON bool `json:"marshal_as_json"`
 
 	// Sub-second precision timestamps are only possible for those using fluentd
 	// v0.14+ and serializing their messages with msgpack.
@@ -54,12 +57,11 @@ type Config struct {
 type Fluent struct {
 	Config
 
-	mubuff  sync.Mutex
-	pending []byte
+	pending chan []byte
+	wg      sync.WaitGroup
 
-	muconn       sync.Mutex
-	conn         net.Conn
-	reconnecting bool
+	muconn sync.Mutex
+	conn   net.Conn
 }
 
 // New creates a new Logger.
@@ -95,10 +97,17 @@ func New(config Config) (f *Fluent, err error) {
 		config.MaxRetryWait = defaultMaxRetryWait
 	}
 	if config.AsyncConnect {
-		f = &Fluent{Config: config, reconnecting: true}
-		go f.reconnect()
+		config.Async = config.Async || config.AsyncConnect
+	}
+	if config.Async {
+		f = &Fluent{
+			Config:  config,
+			pending: make(chan []byte, config.BufferLimit),
+		}
+		f.wg.Add(1)
+		go f.run()
 	} else {
-		f = &Fluent{Config: config, reconnecting: false}
+		f = &Fluent{Config: config}
 		err = f.connect()
 	}
 	return
@@ -192,14 +201,11 @@ func (f *Fluent) PostRawData(data []byte) {
 }
 
 func (f *Fluent) postRawData(data []byte) error {
-	if err := f.appendBuffer(data); err != nil {
-		return err
+	if f.Config.Async {
+		return f.appendBuffer(data)
 	}
-	if err := f.send(); err != nil {
-		f.close()
-		return err
-	}
-	return nil
+	// Synchronous write
+	return f.write(data)
 }
 
 // For sending forward protocol adopted JSON
@@ -232,10 +238,11 @@ func (f *Fluent) EncodeData(tag string, tm time.Time, message interface{}) (data
 	return
 }
 
-// Close closes the connection.
+// Close closes the connection, waiting for pending logs to be sent
 func (f *Fluent) Close() (err error) {
-	if len(f.pending) > 0 {
-		err = f.send()
+	if f.Config.Async {
+		close(f.pending)
+		f.wg.Wait()
 	}
 	f.close()
 	return
@@ -243,12 +250,11 @@ func (f *Fluent) Close() (err error) {
 
 // appendBuffer appends data to buffer with lock.
 func (f *Fluent) appendBuffer(data []byte) error {
-	f.mubuff.Lock()
-	defer f.mubuff.Unlock()
-	if len(f.pending)+len(data) > f.Config.BufferLimit {
-		return errors.New(fmt.Sprintf("fluent#appendBuffer: Buffer full, limit %v", f.Config.BufferLimit))
+	select {
+	case f.pending <- data:
+	default:
+		return fmt.Errorf("fluent#appendBuffer: Buffer full, limit %v", f.Config.BufferLimit)
 	}
-	f.pending = append(f.pending, data...)
 	return nil
 }
 
@@ -264,8 +270,6 @@ func (f *Fluent) close() {
 
 // connect establishes a new connection using the specified transport.
 func (f *Fluent) connect() (err error) {
-	f.muconn.Lock()
-	defer f.muconn.Unlock()
 
 	switch f.Config.FluentNetwork {
 	case "tcp":
@@ -275,66 +279,63 @@ func (f *Fluent) connect() (err error) {
 	default:
 		err = net.UnknownNetworkError(f.Config.FluentNetwork)
 	}
+	return err
+}
 
-	if err == nil {
-		f.reconnecting = false
+func (f *Fluent) run() {
+	for {
+		select {
+		case entry, ok := <-f.pending:
+			if !ok {
+				f.wg.Done()
+				return
+			}
+			err := f.write(entry)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "[%s] Unable to send logs to fluentd, reconnecting...\n", time.Now().Format(time.RFC3339))
+			}
+		}
 	}
-	return
 }
 
 func e(x, y float64) int {
 	return int(math.Pow(x, y))
 }
 
-func (f *Fluent) reconnect() {
-	for i := 0; ; i++ {
-		err := f.connect()
-		if err == nil {
-			f.send()
-			return
-		}
-		if i == f.Config.MaxRetry {
-			// TODO: What we can do when connection failed MaxRetry times?
-			panic("fluent#reconnect: failed to reconnect!")
-		}
-		waitTime := f.Config.RetryWait * e(defaultReconnectWaitIncreRate, float64(i-1))
-		if waitTime > f.Config.MaxRetryWait {
-			waitTime = f.Config.MaxRetryWait
-		}
-		time.Sleep(time.Duration(waitTime) * time.Millisecond)
-	}
-}
+func (f *Fluent) write(data []byte) error {
 
-func (f *Fluent) send() error {
-	f.muconn.Lock()
-	defer f.muconn.Unlock()
+	for i := 0; i < f.Config.MaxRetry; i++ {
 
-	if f.conn == nil {
-		if f.reconnecting == false {
-			f.reconnecting = true
-			go f.reconnect()
+		// Connect if needed
+		f.muconn.Lock()
+		if f.conn == nil {
+			err := f.connect()
+			if err != nil {
+				f.muconn.Unlock()
+				waitTime := f.Config.RetryWait * e(defaultReconnectWaitIncreRate, float64(i-1))
+				if waitTime > f.Config.MaxRetryWait {
+					waitTime = f.Config.MaxRetryWait
+				}
+				time.Sleep(time.Duration(waitTime) * time.Millisecond)
+				continue
+			}
 		}
-		return errors.New("fluent#send: can't send logs, client is reconnecting")
-	}
+		f.muconn.Unlock()
 
-	f.mubuff.Lock()
-	defer f.mubuff.Unlock()
-
-	var err error
-	if len(f.pending) > 0 {
+		// We're connected, write data
 		t := f.Config.WriteTimeout
 		if time.Duration(0) < t {
 			f.conn.SetWriteDeadline(time.Now().Add(t))
 		} else {
 			f.conn.SetWriteDeadline(time.Time{})
 		}
-		_, err = f.conn.Write(f.pending)
+		_, err := f.conn.Write(data)
 		if err != nil {
-			f.conn.Close()
-			f.conn = nil
+			f.close()
 		} else {
-			f.pending = f.pending[:0]
+			return err
 		}
 	}
-	return err
+
+	return errors.New("fluent#write: failed to reconnect")
 }

--- a/fluent/fluent.go
+++ b/fluent/fluent.go
@@ -97,6 +97,7 @@ func New(config Config) (f *Fluent, err error) {
 		config.MaxRetryWait = defaultMaxRetryWait
 	}
 	if config.AsyncConnect {
+		fmt.Fprintf(os.Stderr, "fluent#New: AsyncConnect is now deprecated, please use Async instead")
 		config.Async = config.Async || config.AsyncConnect
 	}
 	if config.Async {
@@ -337,5 +338,5 @@ func (f *Fluent) write(data []byte) error {
 		}
 	}
 
-	return errors.New("fluent#write: failed to reconnect")
+	return fmt.Errorf("fluent#write: failed to reconnect, max retry: %v", f.Config.MaxRetry)
 }

--- a/fluent/fluent_test.go
+++ b/fluent/fluent_test.go
@@ -210,9 +210,13 @@ func Test_SubSecondPrecision(t *testing.T) {
 		t.Error(err)
 	}
 
-	expected := "\x94\xA3tag\xC7\x08\x00K\x92\u001Ee\x00\x00\x01\x00\x81\xA3foo\xA3bar\xC0"
+	// 8 bytes timestamp can be represented using ext 8 or fixext 8
+	expected1 := "\x94\xA3tag\xC7\x08\x00K\x92\u001Ee\x00\x00\x01\x00\x81\xA3foo\xA3bar\xC0"
+	expected2 := "\x94\xa3tag\xD7\x00K\x92\x1Ee\x00\x00\x01\x00\x81\xA3foo\xA3bar\xc0"
 	actual := string(encodedData)
-	assert.Equal(t, expected, actual)
+	if actual != expected1 && actual != expected2 {
+		t.Errorf("got %x,\n         except %x\n             or %x", actual, expected1, expected2)
+	}
 }
 
 func Test_MarshalAsJSON(t *testing.T) {

--- a/fluent/testdata/config.json
+++ b/fluent/testdata/config.json
@@ -5,10 +5,10 @@
   "fluent_socket_path":"/var/tmp/fluent.sock",
   "timeout":3000,
   "write_timeout":6000,
-  "buffer_limit":200,
+  "buffer_limit":10,
   "retry_wait":5,
   "max_retry":3,
   "tag_prefix":"fluent",
-  "async_connect": false,
+  "async": false,
   "marshal_as_json": true
 }


### PR DESCRIPTION
This PR is basically #52 without breaking changes.

We are using fluent logging in performance critical services and want to ensure fluent request can't impact service response time.

Noticeable changes in behavior are:
* No more panic when max retry is exceeded.
* Default synchronous mode is always synchronous (including reconnection). Asynchronous mode is always asynchronous (both connection and send).

Should fix #33, #54 