### PR TITLE
travis checks against golang 1.8, 1.9, 1.11 and tip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 go:
-  - 1.3
-  - 1.4
-  - 1.5
+  - 1.8
+  - 1.9
+  - 1.11
   - tip
 install:
   - go get github.com/bmizerany/assert


### PR DESCRIPTION
Fixing outdated golang versions in CI, see https://github.com/fluent/fluent-logger-golang/issues/60

Signed-off-by: Gergely Szabo <gergely.szabo@origoss.com>