### PR TITLE
`AsyncStop` option for graceful stop in async mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ Since the default is zero value, Write will not time out.
 Enable asynchronous I/O (connect and write) for sending events to Fluentd.
 The default is false.
 
-### AsyncStop
+### ForceStopAsyncSend
 
-Enables discarding bufferred events when Close() is called in Async mode. If Fluentd is continuously unavailable, Close() will block forever otherwise.
+When Async is enabled, immediately discard the event queue on close() and return (instead of trying MaxRetry times for each event in the queue before returning)
 The default is false.
 
 ### RequestAck

--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ Since the default is zero value, Write will not time out.
 Enable asynchronous I/O (connect and write) for sending events to Fluentd.
 The default is false.
 
+### AsyncStop
+
+Enables discarding bufferred events when Close() is called in Async mode. If Fluentd is continuously unavailable, Close() will block forever otherwise.
+The default is false.
+
 ### RequestAck
 
 Sets whether to request acknowledgment from Fluentd to increase the reliability

--- a/fluent/fluent.go
+++ b/fluent/fluent.go
@@ -354,6 +354,7 @@ func (f *Fluent) connect() (err error) {
 
 func (f *Fluent) run() {
 	drainEvents := false
+	var emitEventDrainMsg sync.Once
 	for {
 		select {
 		case stopRunning, ok := <-f.stopRunning:
@@ -369,7 +370,7 @@ func (f *Fluent) run() {
 				return
 			}
 			if drainEvents {
-				fmt.Fprintf(os.Stderr, "[%s] Unable to send logs to fluentd, discarding...\n", time.Now().Format(time.RFC3339))
+				emitEventDrainMsg.Do(func() { fmt.Fprintf(os.Stderr, "[%s] Discarding queued events...\n", time.Now().Format(time.RFC3339)) })
 				continue
 			}
 			err := f.write(entry)

--- a/fluent/fluent.go
+++ b/fluent/fluent.go
@@ -357,13 +357,6 @@ func (f *Fluent) run() {
 	var emitEventDrainMsg sync.Once
 	for {
 		select {
-		case stopRunning, ok := <-f.stopRunning:
-			if stopRunning || !ok {
-				drainEvents = true
-			}
-		default:
-		}
-		select {
 		case entry, ok := <-f.pending:
 			if !ok {
 				f.wg.Done()
@@ -377,6 +370,13 @@ func (f *Fluent) run() {
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "[%s] Unable to send logs to fluentd, reconnecting...\n", time.Now().Format(time.RFC3339))
 			}
+		}
+		select {
+		case stopRunning, ok := <-f.stopRunning:
+			if stopRunning || !ok {
+				drainEvents = true
+			}
+		default:
 		}
 	}
 }

--- a/fluent/fluent.go
+++ b/fluent/fluent.go
@@ -37,19 +37,19 @@ const (
 )
 
 type Config struct {
-	FluentPort       int           `json:"fluent_port"`
-	FluentHost       string        `json:"fluent_host"`
-	FluentNetwork    string        `json:"fluent_network"`
-	FluentSocketPath string        `json:"fluent_socket_path"`
-	Timeout          time.Duration `json:"timeout"`
-	WriteTimeout     time.Duration `json:"write_timeout"`
-	BufferLimit      int           `json:"buffer_limit"`
-	RetryWait        int           `json:"retry_wait"`
-	MaxRetry         int           `json:"max_retry"`
-	MaxRetryWait     int           `json:"max_retry_wait"`
-	TagPrefix        string        `json:"tag_prefix"`
-	Async            bool          `json:"async"`
-	AsyncStop        bool          `json:"async_stop"`
+	FluentPort         int           `json:"fluent_port"`
+	FluentHost         string        `json:"fluent_host"`
+	FluentNetwork      string        `json:"fluent_network"`
+	FluentSocketPath   string        `json:"fluent_socket_path"`
+	Timeout            time.Duration `json:"timeout"`
+	WriteTimeout       time.Duration `json:"write_timeout"`
+	BufferLimit        int           `json:"buffer_limit"`
+	RetryWait          int           `json:"retry_wait"`
+	MaxRetry           int           `json:"max_retry"`
+	MaxRetryWait       int           `json:"max_retry_wait"`
+	TagPrefix          string        `json:"tag_prefix"`
+	Async              bool          `json:"async"`
+	ForceStopAsyncSend bool          `json:"force_stop_async_send"`
 	// Deprecated: Use Async instead
 	AsyncConnect  bool `json:"async_connect"`
 	MarshalAsJSON bool `json:"marshal_as_json"`
@@ -307,7 +307,7 @@ func (f *Fluent) EncodeData(tag string, tm time.Time, message interface{}) (msg 
 // Close closes the connection, waiting for pending logs to be sent
 func (f *Fluent) Close() (err error) {
 	if f.Config.Async {
-		if f.Config.AsyncStop {
+		if f.Config.ForceStopAsyncSend {
 			f.stopRunning <- true
 			close(f.stopRunning)
 		}
@@ -360,7 +360,7 @@ func (f *Fluent) run() {
 			if stopRunning || !ok {
 				drainEvents = true
 			}
-default:
+		default:
 		}
 		select {
 		case entry, ok := <-f.pending:

--- a/fluent/fluent_test.go
+++ b/fluent/fluent_test.go
@@ -260,6 +260,7 @@ func TestJsonConfig(t *testing.T) {
 		MaxRetry:         3,
 		TagPrefix:        "fluent",
 		Async:            false,
+		AsyncStop:        false,
 		MarshalAsJSON:    true,
 	}
 

--- a/fluent/fluent_test.go
+++ b/fluent/fluent_test.go
@@ -249,19 +249,19 @@ func TestJsonConfig(t *testing.T) {
 	}
 	var got Config
 	expect := Config{
-		FluentPort:       8888,
-		FluentHost:       "localhost",
-		FluentNetwork:    "tcp",
-		FluentSocketPath: "/var/tmp/fluent.sock",
-		Timeout:          3000,
-		WriteTimeout:     6000,
-		BufferLimit:      10,
-		RetryWait:        5,
-		MaxRetry:         3,
-		TagPrefix:        "fluent",
-		Async:            false,
-		AsyncStop:        false,
-		MarshalAsJSON:    true,
+		FluentPort:         8888,
+		FluentHost:         "localhost",
+		FluentNetwork:      "tcp",
+		FluentSocketPath:   "/var/tmp/fluent.sock",
+		Timeout:            3000,
+		WriteTimeout:       6000,
+		BufferLimit:        10,
+		RetryWait:          5,
+		MaxRetry:           3,
+		TagPrefix:          "fluent",
+		Async:              false,
+		ForceStopAsyncSend: false,
+		MarshalAsJSON:      true,
 	}
 
 	err = json.Unmarshal(b, &got)

--- a/fluent/testdata/config.json
+++ b/fluent/testdata/config.json
@@ -10,6 +10,6 @@
   "max_retry":3,
   "tag_prefix":"fluent",
   "async": false,
-  "async_stop": false,
+  "force_stop_async_send": false,
   "marshal_as_json": true
 }

--- a/fluent/testdata/config.json
+++ b/fluent/testdata/config.json
@@ -10,5 +10,6 @@
   "max_retry":3,
   "tag_prefix":"fluent",
   "async": false,
+  "async_stop": false,
   "marshal_as_json": true
 }


### PR DESCRIPTION
As I understand, existing behaviour in Async mode is:

 * Add events to the end of the buffer. Return an error if the buffer is full
 * Take events from the front of the buffer, for each event try to send to fluentd `MaxRetry` times, and if still not successfully sent the event is discarded
 * When `Close()` is called, the pending event channel is closed and attempting to add any new events will return an error
 * When `Close()` is called, it will block until all remaining events in the buffer have either been successfully sent, or each one has run through it's `MaxRetry` number of failures. This means that `Close()` can block for a very long time if the number of unsent events is large.

This PR introduces a new option `AsyncStop`. When true in Async mode and Close() is called, the current write() / MaxRetries iteration will complete for the single event in-progress, and then any remaining events in the buffer will be discarded. This may help to significantly reduce the time that `Close()` blocks when fluentd is continuously available.

 * Possible fix for #71 