### PR TITLE
fix compilation error of Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ package main
 import (
   "github.com/fluent/fluent-logger-golang/fluent"
   "fmt"
-  "time"
+  //"time"
 )
 
 func main() {


### PR DESCRIPTION
Unused package "time" is imported in Example code.
It causes compilation error.

https://play.golang.org/p/cBa7H7OMy-Z

My patch is to fix it.