### PR TITLE
Properly stop logger during (re)connect failure

### DIFF
--- a/fluent/fluent.go
+++ b/fluent/fluent.go
@@ -1,10 +1,12 @@
 package fluent
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
+	"math/rand"
 	"net"
 	"os"
 	"reflect"
@@ -15,7 +17,6 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/binary"
-	"math/rand"
 
 	"github.com/tinylib/msgp/msgp"
 )
@@ -36,6 +37,10 @@ const (
 	// with fluentd versions v0.14 and above.
 	defaultSubSecondPrecision = false
 )
+
+// randomGenerator is used by getUniqueId to generate ack hashes. Its value is replaced
+// during tests with a deterministic function.
+var randomGenerator = rand.Uint64
 
 type Config struct {
 	FluentPort          int           `json:"fluent_port"`
@@ -86,15 +91,22 @@ type msgToSend struct {
 type Fluent struct {
 	Config
 
-	dialer       dialer
-	stopRunning  chan bool
-	pending      chan *msgToSend
-	pendingMutex sync.RWMutex
-	chanClosed   bool
-	wg           sync.WaitGroup
+	dialer dialer
+	// stopRunning is used in async mode to signal to run() it should abort.
+	stopRunning chan struct{}
+	// cancelDialings is used by Close() to stop any in-progress dialing.
+	cancelDialings context.CancelFunc
+	pending        chan *msgToSend
+	pendingMutex   sync.RWMutex
+	chanClosed     bool
+	wg             sync.WaitGroup
 
 	muconn sync.Mutex
 	conn   net.Conn
+}
+
+type dialer interface {
+	DialContext(ctx context.Context, network, address string) (net.Conn, error)
 }
 
 // New creates a new Logger.
@@ -105,10 +117,6 @@ func New(config Config) (*Fluent, error) {
 	return newWithDialer(config, &net.Dialer{
 		Timeout: config.Timeout,
 	})
-}
-
-type dialer interface {
-	Dial(string, string) (net.Conn, error)
 }
 
 func newWithDialer(config Config, d dialer) (f *Fluent, err error) {
@@ -145,21 +153,25 @@ func newWithDialer(config Config, d dialer) (f *Fluent, err error) {
 	}
 
 	if config.Async {
+		ctx, cancel := context.WithCancel(context.Background())
+
 		f = &Fluent{
-			Config:       config,
-			dialer:       d,
-			pending:      make(chan *msgToSend, config.BufferLimit),
-			pendingMutex: sync.RWMutex{},
-			stopRunning:  make(chan bool, 1),
+			Config:         config,
+			dialer:         d,
+			cancelDialings: cancel,
+			pending:        make(chan *msgToSend, config.BufferLimit),
+			pendingMutex:   sync.RWMutex{},
+			stopRunning:    make(chan struct{}),
 		}
+
 		f.wg.Add(1)
-		go f.run()
+		go f.run(ctx)
 	} else {
 		f = &Fluent{
 			Config: config,
 			dialer: d,
 		}
-		err = f.connect()
+		err = f.connect(context.Background())
 	}
 	return
 }
@@ -256,7 +268,7 @@ func (f *Fluent) postRawData(msg *msgToSend) error {
 		return f.appendBuffer(msg)
 	}
 	// Synchronous write
-	return f.write(msg)
+	return f.write(context.Background(), msg)
 }
 
 // For sending forward protocol adopted JSON
@@ -290,7 +302,7 @@ func getUniqueID(timeUnix int64) (string, error) {
 		enc.Close()
 		return "", err
 	}
-	if err := binary.Write(enc, binary.LittleEndian, rand.Uint64()); err != nil {
+	if err := binary.Write(enc, binary.LittleEndian, randomGenerator()); err != nil {
 		enc.Close()
 		return "", err
 	}
@@ -326,9 +338,9 @@ func (f *Fluent) EncodeData(tag string, tm time.Time, message interface{}) (msg 
 	return
 }
 
-// Close closes the connection, waiting for pending logs to be sent
+// Close closes the connection, waiting for pending logs to be sent. If the client is
+// running in async mode, the run() goroutine exits before Close() returns.
 func (f *Fluent) Close() (err error) {
-	defer f.close(f.conn)
 	if f.Config.Async {
 		f.pendingMutex.Lock()
 		if f.chanClosed {
@@ -337,14 +349,35 @@ func (f *Fluent) Close() (err error) {
 		}
 		f.chanClosed = true
 		f.pendingMutex.Unlock()
+
 		if f.Config.ForceStopAsyncSend {
-			f.stopRunning <- true
 			close(f.stopRunning)
+			f.cancelDialings()
 		}
+
 		close(f.pending)
+		// If ForceStopAsyncSend is false, all logs in the channel have to be sent
+		// before closing the connection. At this point chanClosed is true so no more
+		// logs are written to the channel and f.pending has been closed, so run()
+		// goroutine will exit as soon as all logs in the channel are sent.
+		if !f.Config.ForceStopAsyncSend {
+			f.wg.Wait()
+		}
+	}
+
+	f.muconn.Lock()
+	f.close()
+	f.muconn.Unlock()
+
+	// If ForceStopAsyncSend is true, we shall close the connection before waiting for
+	// run() goroutine to exit to be sure we aren't waiting on ack message that might
+	// never come (eg. because fluentd server is down). However we want to be sure the
+	// run() goroutine stops before returning from Close().
+	if f.Config.ForceStopAsyncSend {
 		f.wg.Wait()
 	}
-	return nil
+
+	return
 }
 
 // appendBuffer appends data to buffer with lock.
@@ -362,49 +395,95 @@ func (f *Fluent) appendBuffer(msg *msgToSend) error {
 	return nil
 }
 
-// close closes the connection.
-func (f *Fluent) close(c net.Conn) {
-	f.muconn.Lock()
-	if f.conn != nil && f.conn == c {
+// close closes the connection. Callers should take care of locking muconn first.
+func (f *Fluent) close() {
+	if f.conn != nil {
 		f.conn.Close()
 		f.conn = nil
 	}
-	f.muconn.Unlock()
 }
 
-// connect establishes a new connection using the specified transport.
-func (f *Fluent) connect() (err error) {
+// connect establishes a new connection using the specified transport. Caller should
+// take care of locking muconn first.
+func (f *Fluent) connect(ctx context.Context) (err error) {
 	switch f.Config.FluentNetwork {
 	case "tcp":
-		f.conn, err = f.dialer.Dial(
+		f.conn, err = f.dialer.DialContext(ctx,
 			f.Config.FluentNetwork,
 			f.Config.FluentHost+":"+strconv.Itoa(f.Config.FluentPort))
 	case "unix":
-		f.conn, err = f.dialer.Dial(
+		f.conn, err = f.dialer.DialContext(ctx,
 			f.Config.FluentNetwork,
 			f.Config.FluentSocketPath)
 	default:
 		err = NewErrUnknownNetwork(f.Config.FluentNetwork)
 	}
+
 	return err
 }
 
-func (f *Fluent) run() {
-	drainEvents := false
-	var emitEventDrainMsg sync.Once
+var errIsClosing = errors.New("fluent logger is closing")
+
+// Caller should take care of locking muconn first.
+func (f *Fluent) connectOrRetry(ctx context.Context) error {
+	// Use a Time channel instead of time.Sleep() to avoid blocking this
+	// goroutine during possibly way too much time (because of the exponential
+	// back-off retry).
+	// time.NewTimer() is used instead of time.After() to avoid leaking the
+	// timer channel (cf. https://pkg.go.dev/time#After).
+	timeout := time.NewTimer(time.Duration(0))
+	defer func() {
+		// timeout.Stop() is called in a function literal instead of being
+		// defered directly
+		timeout.Stop()
+	}()
+
+	for i := 0; i < f.Config.MaxRetry; i++ {
+		select {
+		case <-timeout.C:
+			err := f.connect(ctx)
+			if err == nil {
+				return nil
+			}
+
+			if _, ok := err.(*ErrUnknownNetwork); ok {
+				return err
+			}
+			if err == context.Canceled {
+				return errIsClosing
+			}
+
+			waitTime := f.Config.RetryWait * e(defaultReconnectWaitIncreRate, float64(i-1))
+			if waitTime > f.Config.MaxRetryWait {
+				waitTime = f.Config.MaxRetryWait
+			}
+
+			timeout = time.NewTimer(time.Duration(waitTime) * time.Millisecond)
+
+			fmt.Fprintf(os.Stderr, "[%s] An error happened during connect: %s. Retrying to connect in %dms.", time.Now().Format(time.RFC3339), err, waitTime)
+		case <-ctx.Done():
+			return errIsClosing
+		}
+	}
+
+	return fmt.Errorf("could not connect to fluentd after %d retries", f.Config.MaxRetry)
+}
+
+// run is the goroutine used to unqueue and write logs in async mode. That
+// goroutine is meant to run during the whole life of the Fluent logger.
+func (f *Fluent) run(ctx context.Context) {
 	for {
 		select {
 		case entry, ok := <-f.pending:
+			// f.stopRunning is closed before f.pending only when ForceStopAsyncSend
+			// is enabled. Otherwise, f.pending is closed when Close() is called.
 			if !ok {
 				f.wg.Done()
 				return
 			}
-			if drainEvents {
-				emitEventDrainMsg.Do(func() { fmt.Fprintf(os.Stderr, "[%s] Discarding queued events...\n", time.Now().Format(time.RFC3339)) })
-				continue
-			}
-			err := f.write(entry)
-			if err != nil {
+
+			err := f.write(ctx, entry)
+			if err != nil && err != errIsClosing {
 				fmt.Fprintf(os.Stderr, "[%s] Unable to send logs to fluentd, reconnecting...\n", time.Now().Format(time.RFC3339))
 			}
 			if f.AsyncResultCallback != nil {
@@ -414,13 +493,11 @@ func (f *Fluent) run() {
 				}
 				f.AsyncResultCallback(data, err)
 			}
-		}
-		select {
-		case stopRunning, ok := <-f.stopRunning:
-			if stopRunning || !ok {
-				drainEvents = true
-			}
-		default:
+		case <-f.stopRunning:
+			fmt.Fprintf(os.Stderr, "[%s] Discarding queued events...\n", time.Now().Format(time.RFC3339))
+
+			f.wg.Done()
+			return
 		}
 	}
 }
@@ -429,63 +506,64 @@ func e(x, y float64) int {
 	return int(math.Pow(x, y))
 }
 
-func (f *Fluent) write(msg *msgToSend) error {
-	var c net.Conn
-	for i := 0; i < f.Config.MaxRetry; i++ {
-		c = f.conn
-		// Connect if needed
-		if c == nil {
-			f.muconn.Lock()
-			if f.conn == nil {
-				err := f.connect()
-				if err != nil {
-					f.muconn.Unlock()
+func (f *Fluent) write(ctx context.Context, msg *msgToSend) error {
+	writer := func() (bool, error) {
+		// This function is used to ensure muconn is properly locked and unlocked
+		// between each retry. This gives the oportunity to other goroutines to
+		// lock it (e.g. to close the connection).
+		f.muconn.Lock()
 
-					if _, ok := err.(*ErrUnknownNetwork); ok {
-						// do not retry on unknown network error
-						break
-					}
-					waitTime := f.Config.RetryWait * e(defaultReconnectWaitIncreRate, float64(i-1))
-					if waitTime > f.Config.MaxRetryWait {
-						waitTime = f.Config.MaxRetryWait
-					}
-					time.Sleep(time.Duration(waitTime) * time.Millisecond)
-					continue
-				}
+		if f.conn == nil {
+			if err := f.connectOrRetry(ctx); err != nil {
+				f.muconn.Unlock()
+				return false, err
 			}
-			c = f.conn
-			f.muconn.Unlock()
 		}
 
-		// We're connected, write msg
 		t := f.Config.WriteTimeout
 		if time.Duration(0) < t {
-			c.SetWriteDeadline(time.Now().Add(t))
+			f.conn.SetWriteDeadline(time.Now().Add(t))
 		} else {
-			c.SetWriteDeadline(time.Time{})
+			f.conn.SetWriteDeadline(time.Time{})
 		}
-		_, err := c.Write(msg.data)
+
+		_, err := f.conn.Write(msg.data)
 		if err != nil {
-			f.close(c)
-		} else {
-			// Acknowledgment check
-			if msg.ack != "" {
-				resp := &AckResp{}
-				if f.Config.MarshalAsJSON {
-					dec := json.NewDecoder(c)
-					err = dec.Decode(resp)
-				} else {
-					r := msgp.NewReader(c)
-					err = resp.DecodeMsg(r)
-				}
-				if err != nil || resp.Ack != msg.ack {
-					f.close(c)
-					continue
-				}
+			f.close()
+			f.muconn.Unlock()
+			return true, err
+		}
+
+		// Unlock muconn before waiting for the ack response (if required) to not block
+		// other messages from being sent (this would greatly degrade performance).
+		f.muconn.Unlock()
+
+		// Acknowledgment check
+		if msg.ack != "" {
+			resp := &AckResp{}
+			if f.Config.MarshalAsJSON {
+				dec := json.NewDecoder(f.conn)
+				err = dec.Decode(resp)
+			} else {
+				r := msgp.NewReader(f.conn)
+				err = resp.DecodeMsg(r)
 			}
+
+			if err != nil || resp.Ack != msg.ack {
+				fmt.Fprintf(os.Stderr, "fluent#write: message ack (%s) doesn't match expected one (%s). Closing connection...", resp.Ack, msg.ack)
+				f.close()
+				return true, err
+			}
+		}
+
+		return false, nil
+	}
+
+	for i := 0; i < f.Config.MaxRetry; i++ {
+		if retry, err := writer(); !retry {
 			return err
 		}
 	}
 
-	return fmt.Errorf("fluent#write: failed to reconnect, max retry: %v", f.Config.MaxRetry)
+	return fmt.Errorf("fluent#write: failed to write after %d attempts", f.Config.MaxRetry)
 }


### PR DESCRIPTION
PR #77 introduced a new parameter named ForceStopAsyncSend. It can be
used to tell the logger to not try to send all the log messages in its
buffer before closing. Without this parameter, the logger hangs out
whenever it has logs to write and the target Fluentd server is down.

But this new parameter is not enough: the connection is currently lazily
initialized when the logger receive its first message. This blocks the
select reading messages from the queue (until the connection is ready).
Moreover, the connection dialing uses an exponential back-off retry.

Because of that, the logger won't look for messages on `stopRunning`
channel (the channel introduced by PR #77), either because it's
blocked by the Sleep used for the retry or because the connection
dialing is waiting until dialing timeout (eg. TCP timeout).

To fix these edge cases, the time.Sleep() used for back-off retry has
been transformed into a time.After() and a new stopAsyncConnect channel
has been introduced to stop it. Moreover, the dialer.Dial() call used
to connect to Fluentd has been replaced with dialer.DialContext() and a
cancellable context is now used to stop the call to that method.

Finally, the Fluent.run() method has been adapted to wait for both new
messages on f.pending and stop signal sent to f.stopRunning channel.
Previously, both channels were selected independently, in a procedural
fashion.

This fix is motivated by the issue described in: moby/moby#40063.