### PR TITLE
Added Power Support ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ go:
   - 1.11
   - 1.12
   - tip
+arch:
+  - amd64
+  - ppc64le
 install:
   - go get github.com/bmizerany/assert
   - go get github.com/philhofer/fwd


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.