### PR TITLE
Fix panic if Close() is called more than once

### DIFF
--- a/fluent/fluent_test.go
+++ b/fluent/fluent_test.go
@@ -615,6 +615,19 @@ func TestNoPanicOnAsyncClose(t *testing.T) {
 	}
 }
 
+func TestNoPanicOnAsyncMultipleClose(t *testing.T) {
+	config := Config{
+		Async: true,
+	}
+	d := newTestDialer()
+	f, err := newWithDialer(config, d)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	f.Close()
+	f.Close()
+}
+
 func TestCloseOnFailingAsyncReconnect(t *testing.T) {
 	t.Skip("Broken tests")
 


### PR DESCRIPTION
When the logger is configured to Async: true, it will panic if Close() is called more than once. This fix just prevents the panic by piggy-backing on the changes made in #93, and returning if chanClosed is already true.

previous to this change, the unit test that I've added would fail like this:

```
% go test ./...     
--- FAIL: TestNoPanicOnAsyncMultipleClose (0.00s)
panic: close of closed channel [recovered]
	panic: close of closed channel

goroutine 57 [running]:
testing.tRunner.func1.1(0x11e60c0, 0x1254e40)
	/usr/local/go/src/testing/testing.go:1076 +0x30d
testing.tRunner.func1(0xc00020ca80)
	/usr/local/go/src/testing/testing.go:1079 +0x41a
panic(0x11e60c0, 0x1254e40)
	/usr/local/go/src/runtime/panic.go:969 +0x175
github.com/fluent/fluent-logger-golang/fluent.(*Fluent).Close(0xc0002102a0, 0x0, 0x0)
	/Users/cssparr/ws/go/src/github.com/fluent/fluent-logger-golang/fluent/fluent.go:338 +0xa9
github.com/fluent/fluent-logger-golang/fluent.TestNoPanicOnAsyncMultipleClose(0xc00020ca80)
	/Users/cssparr/ws/go/src/github.com/fluent/fluent-logger-golang/fluent/fluent_test.go:628 +0x19f
testing.tRunner(0xc00020ca80, 0x1225f48)
	/usr/local/go/src/testing/testing.go:1127 +0xef
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1178 +0x386
FAIL	github.com/fluent/fluent-logger-golang/fluent	1.036s
FAIL
```