### PR TITLE
Replace the build status badge with GitHub Workflow's one

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 fluent-logger-golang
 ====
 
-[![Build Status](https://travis-ci.org/fluent/fluent-logger-golang.png?branch=master)](https://travis-ci.org/fluent/fluent-logger-golang)
+[![Build Status](https://github.com/fluent/fluent-logger-golang/actions/workflows/ci.yaml/badge.svg?branch=master)](https://github.com/fluent/fluent-logger-golang/actions)
 [![GoDoc](https://godoc.org/github.com/fluent/fluent-logger-golang/fluent?status.svg)](https://godoc.org/github.com/fluent/fluent-logger-golang/fluent)
 
 ## A structured event logger for Fluentd (Golang)


### PR DESCRIPTION
We deprecated running tests on Travis in bfce90de9. Update the
build status badge accordingly.

Current display:

> ![before](https://user-images.githubusercontent.com/8974561/138375768-e4c90680-8672-493a-86ad-958c970f2e94.png)

After this patch:

> ![after](https://user-images.githubusercontent.com/8974561/138375763-9551e0c6-e0ae-4272-9ccd-79a5e7e800ce.png)

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>