### PR TITLE
Prepare documentation for v1.8.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,24 @@ Skip verifying the server certificate. Useful for development and testing. The d
 
 This logger doesn't support those features. Patches are welcome!
 
+### Is it allowed to call `Fluent.Post()` after connection close?
+
+Before v1.8.0, the Fluent logger silently reopened connections whenever
+`Fluent.Post()` was called.
+
+```go
+logger, _ := fluent.New(fluent.Config{})
+logger.Post(tag, data)
+logger.Close()
+logger.Post(tag, data)  /* reopen connection */
+```
+
+However, this behavior was confusing, in particular when multiple goroutines
+were involved. Starting v1.8.0, the logger no longer accepts `Fluent.Post()`
+after `Fluent.Close()`, and instead returns a "Logger already closed" error.
+
 ## Tests
 ```
+
 go test
 ```

--- a/README.md
+++ b/README.md
@@ -60,7 +60,12 @@ f := fluent.New(fluent.Config{FluentPort: 80, FluentHost: "example.com"})
 
 ### FluentNetwork
 
-Specify the network protocol, as "tcp" (use `FluentHost` and `FluentPort`) or "unix" (use `FluentSocketPath`).
+Specify the network protocol. The supported values are:
+
+ * "tcp" (use `FluentHost` and `FluentPort`)
+ * "tls" (use`FluentHost` and `FluentPort`)
+ * "unix" (use `FluentSocketPath`)
+
 The default is "tcp".
 
 ### FluentHost
@@ -141,6 +146,10 @@ The default is false.
 
 Sets whether to request acknowledgment from Fluentd to increase the reliability
 of the connection. The default is false.
+
+### TlsInsecureSkipVerify
+
+Skip verifying the server certificate. Useful for development and testing. The default is false.
 
 ## FAQ
 


### PR DESCRIPTION

* Document new TLS parameters in README.md
* d7068a9 changed the behavior of `Fluent.Close()` so that it
  finalizes the logger instance inrevocably.
  This adds documentation about the new behavior in README.md