### PR TITLE
Feature: periodically reconnect to fluentd-address

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,11 @@ When Async is enabled, if this is callback is provided, it will be called on eve
 takes two arguments - a `[]byte` of the message that was to be sent and an `error`. If the `error` is not nil this means the 
 delivery of the message was unsuccessful.
 
+### AsyncReconnectInterval
+When async is enabled, this option defines the interval (ms) at which the connection
+to the fluentd-address is re-established. This option is useful if the address
+may resolve to one or more IP addresses, e.g. a Consul service address.
+
 ### SubSecondPrecision
 
 Enable time encoding as EventTime, which contains sub-second precision values. The messages encoded with this option can be received only by Fluentd v0.14 or later.

--- a/fluent/fluent.go
+++ b/fluent/fluent.go
@@ -68,7 +68,7 @@ type Config struct {
 	// AsyncReconnectInterval defines the interval (ms) at which the connection
 	// to the fluentd-address is re-established. This option is useful if the address
 	// may resolve to one or more IP addresses, e.g. a Consul service address.
-	AsyncReconnectInterval int64 `json:"async_reconnect_interval"`
+	AsyncReconnectInterval int `json:"async_reconnect_interval"`
 
 	// Sub-second precision timestamps are only possible for those using fluentd
 	// v0.14+ and serializing their messages with msgpack.

--- a/fluent/fluent.go
+++ b/fluent/fluent.go
@@ -523,6 +523,7 @@ func (f *Fluent) run(ctx context.Context) {
 			if f.AsyncReconnectInterval > 0 {
 				if time.Since(f.latestReconnectTime) > time.Duration(f.AsyncReconnectInterval)*time.Millisecond {
 					f.muconn.Lock()
+					f.close()
 					f.connectWithRetry(ctx)
 					f.muconn.Unlock()
 				}

--- a/fluent/version.go
+++ b/fluent/version.go
@@ -1,3 +1,3 @@
 package fluent
 
-const Version = "1.4.0"
+const Version = "1.9.0"


### PR DESCRIPTION
Signed-off-by: Conor Evans <coevans@tcd.ie>

Closes #110 

**Motivation:**

In cases where the FluentHost can resolve to one of many IPs (e.g. a Consul service address), periodic reconnection is a desirable feature. In a Consul example, a member can be marked unhealthy and leave the service pool, or new members can be added to the service pool. While `ForceStopAsyncSend` is welcomed in that it prevents Docker containers hanging, but it doesn't prevent log loss, and a single application with a log spike can still overwhelm a fluentd worker. If periodic reconnection were in place, FluentHost could resolve to a new address and continue logging.

**Implementation:**

I initialize considered spawning a separate goroutine `reconnect` with a Ticker, but thought that closing the goroutine reliably could be difficult, and that if the `AsyncReconnectInterval` were too long (even 5s would be a pretty long time to come back around to a new time to select the stopRunning channel and end the goroutine). So I piggybacked on `run` and used a `lastReconnectTime` implementation instead. I lock/unlock the muconn around the call as directed by `connectWithRetry` (no `defer` since we want it unlocked straight away for `writeWithRetry` soon thereafter.

**Considerations:**
I don't see any performance tests that can be benchmarked, but I tested two Docker applications side-by-side, one with the fluentd logging driver, the other using `fluent.Post` based on my fork, and the applications were logging consistently (w.r.t volume).

I went with ms as the unit for `AsyncReconnectInterval` because it's consistent with other config attributes (e.g. RetryWait). Since this library is expected to support go1.13, go1.16, and go1.17 per the CI config, I couldn't use the `UnixMilli` method from go1.17 -- at some point in the future the comments can be removed and the code updated.

**Testing:**
Use a FluentHost that can resolve to one or more IPs (e.g. a Consul service address). Observe that it is possible for the FluentHost to change now that reconnection occurs.