### PR TITLE
Update actions, remove use of deprecated package, and some refactor / fixes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,12 +15,12 @@ jobs:
       matrix:
         os: [ubuntu, macos, windows]
         golang: ['1.13', '1.16', '1.17']
-        # currently, we cannot run non-x86_64 machines on Github Actions cloud env.
+        # currently, we cannot run non-x86_64 machines on GitHub Actions cloud env.
     runs-on: ${{ matrix.os }}-latest
     name: CI golang ${{ matrix.golang }} on ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.golang }}
       - name: Change GO11MODULES

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,6 @@ jobs:
         run: go env -w GO111MODULE=auto
       - name: Install requirements
         run: |
-          go get github.com/bmizerany/assert
           go get github.com/philhofer/fwd
           go get github.com/tinylib/msgp
       - name: Test

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ package main
 
 import (
 	"fmt"
-	// "time"
+	"time"
 
 	"github.com/fluent/fluent-logger-golang/fluent"
 )
@@ -43,10 +43,14 @@ func main() {
 		"foo":  "bar",
 		"hoge": "hoge",
 	}
-	error := logger.Post(tag, data)
-	// error = logger.PostWithTime(tag, time.Now(), data)
-	if error != nil {
-		panic(error)
+	err = logger.Post(tag, data)
+	if err != nil {
+		panic(err)
+	}
+
+	err = logger.PostWithTime(tag, time.Now(), data)
+	if err != nil {
+		panic(err)
 	}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ fluent-logger-golang
 
 ## How to install
 
-```
-go get github.com/fluent/fluent-logger-golang/fluent
+```bash
+go get github.com/fluent/fluent-logger-golang/fluent@latest
 ```
 
 ## Usage
 
 Install the package with `go get` and use `import` to include it in your project.
 
-```
+```go
 import "github.com/fluent/fluent-logger-golang/fluent"
 ```
 
@@ -26,27 +26,28 @@ import "github.com/fluent/fluent-logger-golang/fluent"
 package main
 
 import (
-  "github.com/fluent/fluent-logger-golang/fluent"
-  "fmt"
-  //"time"
+	"fmt"
+	// "time"
+
+	"github.com/fluent/fluent-logger-golang/fluent"
 )
 
 func main() {
-  logger, err := fluent.New(fluent.Config{})
-  if err != nil {
-    fmt.Println(err)
-  }
-  defer logger.Close()
-  tag := "myapp.access"
-  var data = map[string]string{
-    "foo":  "bar",
-    "hoge": "hoge",
-  }
-  error := logger.Post(tag, data)
-  // error := logger.PostWithTime(tag, time.Now(), data)
-  if error != nil {
-    panic(error)
-  }
+	logger, err := fluent.New(fluent.Config{})
+	if err != nil {
+		fmt.Println(err)
+	}
+	defer logger.Close()
+	tag := "myapp.access"
+	data := map[string]string{
+		"foo":  "bar",
+		"hoge": "hoge",
+	}
+	error := logger.Post(tag, data)
+	// error = logger.PostWithTime(tag, time.Now(), data)
+	if error != nil {
+		panic(error)
+	}
 }
 ```
 
@@ -181,7 +182,7 @@ were involved. Starting v1.8.0, the logger no longer accepts `Fluent.Post()`
 after `Fluent.Close()`, and instead returns a "Logger already closed" error.
 
 ## Tests
-```
 
+```bash
 go test
 ```

--- a/_examples/main.go
+++ b/_examples/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"time"
 
-	"../fluent"
+	"github.com/fluent/fluent-logger-golang/fluent"
 )
 
 func main() {
@@ -15,9 +15,10 @@ func main() {
 	}
 	defer logger.Close()
 	tag := "myapp.access"
-	var data = map[string]string{
+	data := map[string]string{
 		"foo":  "bar",
-		"hoge": "hoge"}
+		"hoge": "hoge",
+	}
 	for i := 0; i < 100; i++ {
 		e := logger.Post(tag, data)
 		if e != nil {

--- a/fluent/fluent.go
+++ b/fluent/fluent.go
@@ -315,7 +315,7 @@ func (chunk *MessageChunk) MarshalJSON() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return []byte(fmt.Sprintf("[\"%s\",%d,%s,%s]", chunk.message.Tag,
+	return []byte(fmt.Sprintf(`["%s",%d,%s,%s]`, chunk.message.Tag,
 		chunk.message.Time, data, option)), err
 }
 

--- a/fluent/fluent.go
+++ b/fluent/fluent.go
@@ -1,8 +1,11 @@
 package fluent
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
+	"encoding/base64"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -14,10 +17,6 @@ import (
 	"strconv"
 	"sync"
 	"time"
-
-	"bytes"
-	"encoding/base64"
-	"encoding/binary"
 
 	"github.com/tinylib/msgp/msgp"
 )
@@ -200,27 +199,26 @@ func newWithDialer(config Config, d dialer) (f *Fluent, err error) {
 //
 // Examples:
 //
-//  // send map[string]
-//  mapStringData := map[string]string{
-//  	"foo":  "bar",
-//  }
-//  f.Post("tag_name", mapStringData)
+//	// send map[string]
+//	mapStringData := map[string]string{
+//		"foo":  "bar",
+//	}
+//	f.Post("tag_name", mapStringData)
 //
-//  // send message with specified time
-//  mapStringData := map[string]string{
-//  	"foo":  "bar",
-//  }
-//  tm := time.Now()
-//  f.PostWithTime("tag_name", tm, mapStringData)
+//	// send message with specified time
+//	mapStringData := map[string]string{
+//		"foo":  "bar",
+//	}
+//	tm := time.Now()
+//	f.PostWithTime("tag_name", tm, mapStringData)
 //
-//  // send struct
-//  structData := struct {
-//  		Name string `msg:"name"`
-//  } {
-//  		"john smith",
-//  }
-//  f.Post("tag_name", structData)
-//
+//	// send struct
+//	structData := struct {
+//			Name string `msg:"name"`
+//	} {
+//			"john smith",
+//	}
+//	f.Post("tag_name", structData)
 func (f *Fluent) Post(tag string, message interface{}) error {
 	timeNow := time.Now()
 	return f.PostWithTime(tag, timeNow, message)

--- a/fluent/fluent_test.go
+++ b/fluent/fluent_test.go
@@ -451,9 +451,9 @@ func TestPostWithTime(t *testing.T) {
 		},
 	}
 
-	for tcname := range testcases {
+	for tcname, tc := range testcases {
+		tc := tc
 		t.Run(tcname, func(t *testing.T) {
-			tc := testcases[tcname]
 			t.Parallel()
 
 			d := newTestDialer()
@@ -506,9 +506,9 @@ func TestReconnectAndResendAfterTransientFailure(t *testing.T) {
 		},
 	}
 
-	for tcname := range testcases {
+	for tcname, tc := range testcases {
+		tc := tc
 		t.Run(tcname, func(t *testing.T) {
-			tc := testcases[tcname]
 			t.Parallel()
 
 			d := newTestDialer()
@@ -588,9 +588,9 @@ func TestCloseOnFailingAsyncConnect(t *testing.T) {
 		},
 	}
 
-	for tcname := range testcases {
+	for tcname, tc := range testcases {
+		tc := tc
 		t.Run(tcname, func(t *testing.T) {
-			tc := testcases[tcname]
 			t.Parallel()
 
 			d := newTestDialer()
@@ -636,22 +636,23 @@ func TestNoPanicOnAsyncClose(t *testing.T) {
 			shouldError: false,
 		},
 	}
-	for _, testcase := range testcases {
-		t.Run(testcase.name, func(t *testing.T) {
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			d := newTestDialer()
-			f, err := newWithDialer(testcase.config, d)
+			f, err := newWithDialer(tc.config, d)
 			if err != nil {
 				t.Errorf("Unexpected error: %v", err)
 			}
-			if testcase.shouldError {
+			if tc.shouldError {
 				f.Close()
 			}
-			e := f.EncodeAndPostData("tag_name", time.Unix(1482493046, 0), map[string]string{"foo": "bar"})
-			if testcase.shouldError {
-				assert.Equal(t, fmt.Errorf("fluent#appendBuffer: Logger already closed"), e)
+			err = f.EncodeAndPostData("tag_name", time.Unix(1482493046, 0), map[string]string{"foo": "bar"})
+			if tc.shouldError {
+				assert.Equal(t, fmt.Errorf("fluent#appendBuffer: Logger already closed"), err)
 			} else {
-				assert.Equal(t, nil, e)
+				assert.Equal(t, nil, err)
 			}
 		})
 	}
@@ -684,9 +685,9 @@ func TestCloseOnFailingAsyncReconnect(t *testing.T) {
 		},
 	}
 
-	for tcname := range testcases {
+	for tcname, tc := range testcases {
+		tc := tc
 		t.Run(tcname, func(t *testing.T) {
-			tc := testcases[tcname]
 			t.Parallel()
 
 			d := newTestDialer()

--- a/fluent/fluent_test.go
+++ b/fluent/fluent_test.go
@@ -103,12 +103,12 @@ func newTestDialer() *testDialer {
 //	conn := d.waitForNextDialing(true, false)
 //	assertReceived(t, // t is *testing.T
 //	    conn.waitForNextWrite(true, ""),
-//	    "[\"tag_name\",1482493046,{\"foo\":\"bar\"},{}]")
+//	    `["tag_name",1482493046,{"foo":"bar"},{}]`)
 //
 //	f.EncodeAndPostData("something_else", time.Unix(1482493050, 0), map[string]string{"bar": "baz"})
 //	assertReceived(t, // t is *testing.T
 //	    conn.waitForNextWrite(true, ""),
-//	    "[\"something_else\",1482493050,{\"bar\":\"baz\"},{}]")
+//	    `["something_else",1482493050,{"bar":"baz"},{}]`)
 //
 // In this example, the 1st connection dialing succeeds but the 1st attempt to write the
 // message is discarded. As the logger discards the connection whenever a message
@@ -118,7 +118,7 @@ func newTestDialer() *testDialer {
 // using assertReceived() to make sure the logger encodes the messages properly.
 //
 // Again, the example above is using async mode thus, calls to f and conn are running in
-// the same goroutine. However in sync mode, all calls to f.EncodeAndPostData() as well
+// the same goroutine. However, in sync mode, all calls to f.EncodeAndPostData() as well
 // as the logger initialization shall be placed in a separate goroutine or the code
 // allowing the dialing and writing attempts (eg. waitForNextDialing() & waitForNextWrite())
 // would never be reached.
@@ -482,14 +482,14 @@ func TestPostWithTime(t *testing.T) {
 			conn := d.waitForNextDialing(true, false)
 			assertReceived(t,
 				conn.waitForNextWrite(true, ""),
-				"[\"acme.tag_name\",1482493046,{\"foo\":\"bar\"},{}]")
+				`["acme.tag_name",1482493046,{"foo":"bar"},{}]`)
 
 			assertReceived(t,
 				conn.waitForNextWrite(true, ""),
-				"[\"acme.tag_name\",1482493050,{\"fluentd\":\"is awesome\"},{}]")
+				`["acme.tag_name",1482493050,{"fluentd":"is awesome"},{}]`)
 			assertReceived(t,
 				conn.waitForNextWrite(true, ""),
-				"[\"acme.tag_name\",1634263200,{\"welcome\":\"to use\"},{}]")
+				`["acme.tag_name",1634263200,{"welcome":"to use"},{}]`)
 		})
 	}
 }
@@ -533,7 +533,7 @@ func TestReconnectAndResendAfterTransientFailure(t *testing.T) {
 			conn := d.waitForNextDialing(true, false)
 			assertReceived(t,
 				conn.waitForNextWrite(true, ""),
-				"[\"tag_name\",1482493046,{\"foo\":\"bar\"},{}]")
+				`["tag_name",1482493046,{"foo":"bar"},{}]`)
 
 			// The next write will fail and the next connection dialing will be dropped
 			// to test if the logger is reconnecting as expected.
@@ -544,7 +544,7 @@ func TestReconnectAndResendAfterTransientFailure(t *testing.T) {
 			conn = d.waitForNextDialing(true, false)
 			assertReceived(t,
 				conn.waitForNextWrite(true, ""),
-				"[\"tag_name\",1482493050,{\"fluentd\":\"is awesome\"},{}]")
+				`["tag_name",1482493050,{"fluentd":"is awesome"},{}]`)
 		})
 	}
 }

--- a/fluent/fluent_test.go
+++ b/fluent/fluent_test.go
@@ -45,18 +45,18 @@ func newTestDialer() *testDialer {
 // For instance, to test an async logger that have to dial 4 times before succeeding,
 // the test should look like this:
 //
-//   d := newTestDialer() // Create a new stubbed dialer
-//   cfg := Config{
-//       Async: true,
-//  	   // ...
-//   }
-//   f := newWithDialer(cfg, d) // Create a fluent logger using the stubbed dialer
-//   f.EncodeAndPostData("tag_name", time.Unix(1482493046, 0), map[string]string{"foo": "bar"})
+//	 d := newTestDialer() // Create a new stubbed dialer
+//	 cfg := Config{
+//	     Async: true,
+//		   // ...
+//	 }
+//	 f := newWithDialer(cfg, d) // Create a fluent logger using the stubbed dialer
+//	 f.EncodeAndPostData("tag_name", time.Unix(1482493046, 0), map[string]string{"foo": "bar"})
 //
-//   d.waitForNextDialing(false, false) // 1st dialing attempt fails
-//   d.waitForNextDialing(false, false) // 2nd attempt fails too
-//   d.waitForNextDialing(false, false) // 3rd attempt fails too
-//   d.waitForNextDialing(true, false) // Finally the 4th attempt succeeds
+//	 d.waitForNextDialing(false, false) // 1st dialing attempt fails
+//	 d.waitForNextDialing(false, false) // 2nd attempt fails too
+//	 d.waitForNextDialing(false, false) // 3rd attempt fails too
+//	 d.waitForNextDialing(true, false) // Finally the 4th attempt succeeds
 //
 // Note that in the above example, the logger operates in async mode. As such,
 // a call to Post, PostWithTime or EncodeAndPostData is needed *before* calling
@@ -67,20 +67,20 @@ func newTestDialer() *testDialer {
 // case, you have to put the calls to newWithDialer() and to EncodeAndPostData()
 // into their own goroutine. An example:
 //
-//   d := newTestDialer() // Create a new stubbed dialer
-//   cfg := Config{
-//       Async: false,
-//  	   // ...
-//   }
-//   go func() {
-//       f := newWithDialer(cfg, d) // Create a fluent logger using the stubbed dialer
-//       f.Close()
-//   }()
+//	 d := newTestDialer() // Create a new stubbed dialer
+//	 cfg := Config{
+//	     Async: false,
+//		   // ...
+//	 }
+//	 go func() {
+//	     f := newWithDialer(cfg, d) // Create a fluent logger using the stubbed dialer
+//	     f.Close()
+//	 }()
 //
-//   d.waitForNextDialing(false, false) // 1st dialing attempt fails
-//   d.waitForNextDialing(false, false) // 2nd attempt fails too
-//   d.waitForNextDialing(false, false) // 3rd attempt fails too
-//   d.waitForNextDialing(true, false) // Finally the 4th attempt succeeds
+//	 d.waitForNextDialing(false, false) // 1st dialing attempt fails
+//	 d.waitForNextDialing(false, false) // 2nd attempt fails too
+//	 d.waitForNextDialing(false, false) // 3rd attempt fails too
+//	 d.waitForNextDialing(true, false) // Finally the 4th attempt succeeds
 //
 // Moreover, waitForNextDialing() returns a *Conn which extends net.Conn to provide testing
 // facilities. For instance, you can call waitForNextWrite() on these connections, to
@@ -91,24 +91,24 @@ func newTestDialer() *testDialer {
 //
 // Here's a full example:
 //
-//   d := newTestDialer()
-//   cfg := Config{Async: true}
+//	d := newTestDialer()
+//	cfg := Config{Async: true}
 //
-//   f := newWithDialer(cfg, d)
-//   f.EncodeAndPostData("tag_name", time.Unix(1482493046, 0), map[string]string{"foo": "bar"})
+//	f := newWithDialer(cfg, d)
+//	f.EncodeAndPostData("tag_name", time.Unix(1482493046, 0), map[string]string{"foo": "bar"})
 //
-//   conn := d.waitForNextDialing(true, false) // Accept the dialing
-//   conn.waitForNextWrite(false, "") // Discard the 1st attempt to write the message
+//	conn := d.waitForNextDialing(true, false) // Accept the dialing
+//	conn.waitForNextWrite(false, "") // Discard the 1st attempt to write the message
 //
-//   conn := d.waitForNextDialing(true, false)
-//   assertReceived(t, // t is *testing.T
-//       conn.waitForNextWrite(true, ""),
-//       "[\"tag_name\",1482493046,{\"foo\":\"bar\"},{}]")
+//	conn := d.waitForNextDialing(true, false)
+//	assertReceived(t, // t is *testing.T
+//	    conn.waitForNextWrite(true, ""),
+//	    "[\"tag_name\",1482493046,{\"foo\":\"bar\"},{}]")
 //
-//   f.EncodeAndPostData("something_else", time.Unix(1482493050, 0), map[string]string{"bar": "baz"})
-//   assertReceived(t, // t is *testing.T
-//       conn.waitForNextWrite(true, ""),
-//       "[\"something_else\",1482493050,{\"bar\":\"baz\"},{}]")
+//	f.EncodeAndPostData("something_else", time.Unix(1482493050, 0), map[string]string{"bar": "baz"})
+//	assertReceived(t, // t is *testing.T
+//	    conn.waitForNextWrite(true, ""),
+//	    "[\"something_else\",1482493050,{\"bar\":\"baz\"},{}]")
 //
 // In this example, the 1st connection dialing succeeds but the 1st attempt to write the
 // message is discarded. As the logger discards the connection whenever a message
@@ -296,7 +296,8 @@ func Test_New_itShouldUseUnixDomainSocketIfUnixSocketSpecified(t *testing.T) {
 
 	f, err := New(Config{
 		FluentNetwork:    network,
-		FluentSocketPath: socketFile})
+		FluentSocketPath: socketFile,
+	})
 	if err != nil {
 		t.Error(err)
 		return
@@ -309,7 +310,8 @@ func Test_New_itShouldUseUnixDomainSocketIfUnixSocketSpecified(t *testing.T) {
 	network = "unixxxx"
 	fUnknown, err := New(Config{
 		FluentNetwork:    network,
-		FluentSocketPath: socketFile})
+		FluentSocketPath: socketFile,
+	})
 	if _, ok := err.(*ErrUnknownNetwork); !ok {
 		t.Errorf("err type: %T", err)
 	}
@@ -335,12 +337,12 @@ func Test_MarshalAsMsgpack(t *testing.T) {
 	f := &Fluent{Config: Config{}}
 
 	tag := "tag"
-	var data = map[string]string{
+	data := map[string]string{
 		"foo":  "bar",
-		"hoge": "hoge"}
+		"hoge": "hoge",
+	}
 	tm := time.Unix(1267867237, 0)
 	result, err := f.EncodeData(tag, tm, data)
-
 	if err != nil {
 		t.Error(err)
 	}
@@ -368,7 +370,6 @@ func Test_SubSecondPrecision(t *testing.T) {
 	encodedData, err := fluent.EncodeData("tag", timestamp, map[string]string{
 		"foo": "bar",
 	})
-
 	// Assert no encoding errors and that the timestamp has been encoded into
 	// the message as expected.
 	if err != nil {
@@ -387,12 +388,12 @@ func Test_SubSecondPrecision(t *testing.T) {
 func Test_MarshalAsJSON(t *testing.T) {
 	f := &Fluent{Config: Config{MarshalAsJSON: true}}
 
-	var data = map[string]string{
+	data := map[string]string{
 		"foo":  "bar",
-		"hoge": "hoge"}
+		"hoge": "hoge",
+	}
 	tm := time.Unix(1267867237, 0)
 	result, err := f.EncodeData("tag", tm, data)
-
 	if err != nil {
 		t.Error(err)
 	}
@@ -472,7 +473,10 @@ func TestPostWithTime(t *testing.T) {
 				_ = f.PostWithTime("tag_name", time.Unix(1482493046, 0), map[string]string{"foo": "bar"})
 				_ = f.PostWithTime("tag_name", time.Unix(1482493050, 0), map[string]string{"fluentd": "is awesome"})
 				_ = f.PostWithTime("tag_name", time.Unix(1634263200, 0),
-					struct {Welcome string `msg:"welcome"`; cannot string}{"to use", "see me"})
+					struct {
+						Welcome string `msg:"welcome"`
+						cannot  string
+					}{"to use", "see me"})
 			}()
 
 			conn := d.waitForNextDialing(true, false)
@@ -755,10 +759,10 @@ func TestSyncWriteAfterCloseFails(t *testing.T) {
 		err = f.PostWithTime("tag_name", time.Unix(1482493050, 0), map[string]string{"foo": "buzz"})
 
 		// The event submission must fail,
-		assert.NotEqual(t, err, nil);
+		assert.NotEqual(t, err, nil)
 
 		// and also must keep Fluentd closed.
-		assert.NotEqual(t, f.closed, false);
+		assert.NotEqual(t, f.closed, false)
 	}()
 
 	conn := d.waitForNextDialing(true, false)


### PR DESCRIPTION
See individual commits for details:


### gha: update actions/checkout@v3, actions/setup-go@v3

Older versions are deprecated, so updating to current versions.

### all: gofmt code for current go versions

### fix example in README

### use string-literals to prevent having to escape quotes

This makes the code and examples slightly more readable.

### tests: make sure to capture test-case in loop

`TestNoPanicOnAsyncClose` was not capturing the testcase, but running
with `t.Parallel()`.

Also updated other tests to use the same approach, and renamed variables
for consistency.

### remove use of deprecated github.com/bmizerany/assert package

The github.com/bmizerany/assert module has been deprecated and is no
longer maintained. In addition, the dependency brings various indirect
dependencies with it;

    module github.com/fluent/fluent-logger-golang
    
    go 1.19
    
    require (
        github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869
        github.com/tinylib/msgp v1.1.6
    )
    
    require (
        github.com/kr/pretty v0.3.1 // indirect
        github.com/kr/text v0.2.0 // indirect
        github.com/philhofer/fwd v1.1.1 // indirect
        github.com/rogpeppe/go-internal v1.9.0 // indirect
    )

The assertion package itself also looks to have some issues. For example,
it's not marked as a `t.Helper()`, and while it includes the location of
the error in the output, the failures are prefixed with the location of
the assertion itself, which is somewhat confusing:

    === RUN   Test_New_itShouldUseDefaultConfigValuesIfNoOtherProvided
        assert.go:15: /Users/thajeztah/go/src/github.com/fluent/fluent-logger-golang/fluent/fluent_test.go:275
        assert.go:62: !  Unexpected: <24224>
    --- FAIL: Test_New_itShouldUseDefaultConfigValuesIfNoOtherProvided (0.00s)
    
    === RUN   Test_New_itShouldUseUnixDomainSocketIfUnixSocketSpecified
        assert.go:15: /Users/thajeztah/go/src/github.com/fluent/fluent-logger-golang/fluent/fluent_test.go:306
        assert.go:62: !  Unexpected: <"unix">
    --- FAIL: Test_New_itShouldUseUnixDomainSocketIfUnixSocketSpecified (0.00s)
    
    === RUN   Test_New_itShouldUseConfigValuesFromArguments
        assert.go:15: /Users/thajeztah/go/src/github.com/fluent/fluent-logger-golang/fluent/fluent_test.go:327
        assert.go:62: !  Unexpected: <6666>
    --- FAIL: Test_New_itShouldUseConfigValuesFromArguments (0.00s)
    
    === RUN   Test_New_itShouldUseConfigValuesFromMashalAsJSONArgument
        assert.go:15: /Users/thajeztah/go/src/github.com/fluent/fluent-logger-golang/fluent/fluent_test.go:333
        assert.go:62: !  Unexpected: <true>
    --- FAIL: Test_New_itShouldUseConfigValuesFromMashalAsJSONArgument (0.00s)
    
    === CONT  TestNoPanicOnAsyncClose/Channel_closed_before_write
        assert.go:15: /Users/thajeztah/go/src/github.com/fluent/fluent-logger-golang/fluent/fluent_test.go:653
    === CONT  TestNoPanicOnAsyncClose/Channel_not_closed_at_all
        assert.go:15: /Users/thajeztah/go/src/github.com/fluent/fluent-logger-golang/fluent/fluent_test.go:655
    === CONT  TestNoPanicOnAsyncClose/Channel_closed_before_write
        assert.go:62: !  Unexpected: <&errors.errorString{s:"fluent#appendBuffer: Logger already closed"}>
    === CONT  TestNoPanicOnAsyncClose/Channel_not_closed_at_all
        assert.go:62: !  Unexpected: <<nil>>

While a good assertion library can help (for example by printing a rich
diff output if a struct does not match), a look at how it's used shows
that most cases are comparing primitive types (int, string, bool). This
patch swaps the library for a local `assertEqual()` utility. With this
patch, test-failures look like the example below:

    === RUN   Test_New_itShouldUseDefaultConfigValuesIfNoOtherProvided
        fluent_test.go:281: got: '24224', expected: '24224'
        fluent_test.go:282: got: '127.0.0.1', expected: '127.0.0.1'
        fluent_test.go:283: got: '3s', expected: '3s'
        fluent_test.go:284: got: '0s', expected: '0s'
        fluent_test.go:285: got: '8192', expected: '8192'
        fluent_test.go:286: got: 'tcp', expected: 'tcp'
        fluent_test.go:287: got: '', expected: ''
    --- FAIL: Test_New_itShouldUseDefaultConfigValuesIfNoOtherProvided (0.00s)
    
    === RUN   Test_New_itShouldUseUnixDomainSocketIfUnixSocketSpecified
        fluent_test.go:312: got: 'unix', expected: 'unix'
        fluent_test.go:313: got: '/tmp/fluent-logger-golang.sock', expected: '/tmp/fluent-logger-golang.sock'
    --- FAIL: Test_New_itShouldUseUnixDomainSocketIfUnixSocketSpecified (0.00s)
    
    === RUN   Test_New_itShouldUseConfigValuesFromArguments
        fluent_test.go:333: got: '6666', expected: '6666'
        fluent_test.go:334: got: 'foobarhost', expected: 'foobarhost'
    --- FAIL: Test_New_itShouldUseConfigValuesFromArguments (0.00s)
    
    === RUN   Test_New_itShouldUseConfigValuesFromMashalAsJSONArgument
        fluent_test.go:339: got: 'true', expected: 'true'
    --- FAIL: Test_New_itShouldUseConfigValuesFromMashalAsJSONArgument (0.00s)
    
    === RUN   TestJsonConfig
        fluent_test.go:441: got: '{FluentPort:8888 FluentHost:localhost FluentNetwork:tcp FluentSocketPath:/var/tmp/fluent.sock Timeout:3µs WriteTimeout:6µs BufferLimit:10 RetryWait:5 MaxRetry:3 MaxRetryWait:0 TagPrefix:fluent Async:false ForceStopAsyncSend:false AsyncResultCallback:<nil> AsyncConnect:false MarshalAsJSON:true AsyncReconnectInterval:0 SubSecondPrecision:false RequestAck:false TlsInsecureSkipVerify:false}', expected: '{FluentPort:8888 FluentHost:localhost FluentNetwork:tcp FluentSocketPath:/var/tmp/fluent.sock Timeout:3µs WriteTimeout:6µs BufferLimit:10 RetryWait:5 MaxRetry:3 MaxRetryWait:0 TagPrefix:fluent Async:false ForceStopAsyncSend:false AsyncResultCallback:<nil> AsyncConnect:false MarshalAsJSON:true AsyncReconnectInterval:0 SubSecondPrecision:false RequestAck:false TlsInsecureSkipVerify:false}'
    --- FAIL: TestJsonConfig (0.00s)
    
    === CONT  TestPostWithTime/without_Async
        fluent_test.go:177: got: '["acme.tag_name",1482493046,{"foo":"bar"},{}]', expected: '["acme.tag_name",1482493046,{"foo":"bar"},{}]'
        fluent_test.go:177: got: '["acme.tag_name",1482493050,{"fluentd":"is awesome"},{}]', expected: '["acme.tag_name",1482493050,{"fluentd":"is awesome"},{}]'
        fluent_test.go:177: got: '["acme.tag_name",1634263200,{"welcome":"to use"},{}]', expected: '["acme.tag_name",1634263200,{"welcome":"to use"},{}]'
    === CONT  TestPostWithTime/with_Async
        fluent_test.go:177: got: '["acme.tag_name",1482493046,{"foo":"bar"},{}]', expected: '["acme.tag_name",1482493046,{"foo":"bar"},{}]'
        fluent_test.go:177: got: '["acme.tag_name",1482493050,{"fluentd":"is awesome"},{}]', expected: '["acme.tag_name",1482493050,{"fluentd":"is awesome"},{}]'
        fluent_test.go:177: got: '["acme.tag_name",1634263200,{"welcome":"to use"},{}]', expected: '["acme.tag_name",1634263200,{"welcome":"to use"},{}]'
    
    === CONT  TestReconnectAndResendAfterTransientFailure/with_Async
        fluent_test.go:177: got: '["tag_name",1482493046,{"foo":"bar"},{}]', expected: '["tag_name",1482493046,{"foo":"bar"},{}]'
    === CONT  TestReconnectAndResendAfterTransientFailure/without_Async
        fluent_test.go:177: got: '["tag_name",1482493046,{"foo":"bar"},{}]', expected: '["tag_name",1482493046,{"foo":"bar"},{}]'
        fluent_test.go:177: got: '["tag_name",1482493050,{"fluentd":"is awesome"},{}]', expected: '["tag_name",1482493050,{"fluentd":"is awesome"},{}]'
    === CONT  TestReconnectAndResendAfterTransientFailure/with_Async
        fluent_test.go:177: got: '["tag_name",1482493050,{"fluentd":"is awesome"},{}]', expected: '["tag_name",1482493050,{"fluentd":"is awesome"},{}]'
    
    === CONT  TestNoPanicOnAsyncClose/Channel_closed_before_write
        fluent_test.go:657: got: 'fluent#appendBuffer: Logger already closed', expected: 'fluent#appendBuffer: Logger already closed'
    === CONT  TestNoPanicOnAsyncClose/Channel_not_closed_at_all
        fluent_test.go:659: got: '<nil>', expected: '<nil>'

The list of dependencies have also been reduced with this patch:

    module github.com/fluent/fluent-logger-golang
    
    go 1.19
    
    require github.com/tinylib/msgp v1.1.6
    
    require github.com/philhofer/fwd v1.1.1 // indirect
