### PR TITLE
Migration to go's test assertion framework. Fixes issue #106

### DIFF
--- a/fluent/fluent_test.go
+++ b/fluent/fluent_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bmizerany/assert"
+	"github.com/stretchr/testify/assert"
 	"github.com/tinylib/msgp/msgp"
 )
 


### PR DESCRIPTION
Migrating from "github.com/bmizerany/assert" (which is not maintained now) to "github.com/stretchr/testify/assert"

Fix for https://github.com/fluent/fluent-logger-golang/issues/106