### PR TITLE
downgrade minimum go version and cleanup actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,7 @@ jobs:
         golang: ['1.23.x', 'oldstable', 'stable']
         # currently, we cannot run non-x86_64 machines on GitHub Actions cloud env.
     runs-on: ${{ matrix.os }}-latest
+    timeout-minutes: 10 # guardrails timeout for the whole job
     env:
       # Setting GOTOOLCHAIN to local tells go
       # to use the bundled Go version rather

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,14 @@
 name: ci
 
+# Default to 'contents: read', which grants actions to read commits.
+#
+# If any permission is set, any permission not included in the list is
+# implicitly set to "none".
+#
+# see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
+permissions:
+  contents: read
+
 on: [push, pull_request]
 
 jobs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,13 +1,6 @@
 name: ci
 
-on:
-  pull_request:
-    branches: '*'
-  push:
-    branches:
-      - master
-      - main
-      - 'release-*'
+on: [push, pull_request]
 
 jobs:
   test:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,9 +14,16 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu, macos, windows]
-        golang: ['1.23', '1.24']
+        # test oldest supported version and currently maintained Go versions.
+        golang: ['1.23.x', 'oldstable', 'stable']
         # currently, we cannot run non-x86_64 machines on GitHub Actions cloud env.
     runs-on: ${{ matrix.os }}-latest
+    env:
+      # Setting GOTOOLCHAIN to local tells go
+      # to use the bundled Go version rather
+      # than fetching the toolchain according to
+      # toolchain directive found in go.mod.
+      GOTOOLCHAIN: local
     name: CI golang ${{ matrix.golang }} on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fluent/fluent-logger-golang
 
-go 1.23.5
+go 1.23.0
 
 require github.com/tinylib/msgp v1.3.0
 


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/50249#discussion_r2166191898

### go.mod: don't enforce go1.23.5 patch version

commit 08fb086bc2859b5a5b29509ed8fead3421d781f9 (https://github.com/fluent/fluent-logger-golang/pull/131) added a go.mod, but
set the minimum required version to the patch version.

Generally, go versions in go.mod, like other dependencies, follow
"MVS" (minimum version selection) conventions, and specify the lowest
possible / supported minimum version. Keeping the version low avoids
unnecessary code churn in projects using this module.

### gha: test against oldest supported and current go versions

Also set GOTOOLCHAIN to "local" to prevent changes in go.mod to
override the version used in tests.

### gha: simplify selection of branches

Omit selecting branches; by default any branch is included.

### gha: set default permissions to "read" only

### gha: set default timeout

GitHub's default timeout is 6 hours, which is really long. Set a
more reasonable timeout to prevent "runnaway" runs from running
for hours before timing out.