### PR TITLE
fix: Add x509 key pair to config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # CHANGELOG
 
-## 1.10.0
+## 10.0.1
+* Support x509 Key Pair option
 
+## 1.10.0
 * Refactor Fluent Logger for Improved Thread Safety and Error Handling
 * Follow the recent Golang module updates
 * Stabilize testing on CI


### PR DESCRIPTION
This pull request adds support for using x509 certificate key pairs for TLS connections in the `fluent` package. It introduces new configuration options for specifying certificate and key files, updates the connection logic to use these files if provided, and documents the change in the changelog.

TLS/x509 certificate support:

* Added `TlsCertFile` and `TlsKeyFile` fields to the `Config` struct, allowing users to specify paths to x509 certificate and key files.
* Updated the TLS connection logic in the `connect` method to load and use the specified x509 certificate and key pair if both are provided.
* Introduced default values for the new certificate and key file configuration options.
* Ensured the new config options are set to their defaults if not specified by the user during initialization.

Documentation:

* Updated `CHANGELOG.md` to reflect the addition of x509 key pair support.